### PR TITLE
feat: add lesson viewer completion flow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,7 @@ Create these issues (titles are exact; each item includes acceptance criteria). 
 
 5) Lesson Viewer (Static Content, Completion Toggle)
 - Acceptance: Student can open Lesson 1 and click “Mark complete”; teacher can view completion list per class.
+- Follow-up: Replace the demo join flow with real class-based access control (see Issue #14).
 
 6) MCQ Quiz (Auto-score)
 - Acceptance: Student completes a 10-question quiz; auto-score saved; teacher sees per-student scores.

--- a/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.tsx
+++ b/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type LessonCompletionListPageProps = {
+  params:
+    | {
+        classId: string;
+        slug: string;
+      }
+    | Promise<{
+        classId: string;
+        slug: string;
+      }>;
+};
+
+export default async function LessonCompletionListPage({
+  params,
+}: LessonCompletionListPageProps) {
+  const { classId, slug } = await Promise.resolve(params);
+
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  const classroom = await prisma.class.findUnique({
+    where: {
+      id: classId,
+    },
+    select: {
+      id: true,
+      name: true,
+      teacherId: true,
+      enrollments: {
+        include: {
+          student: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!classroom) {
+    notFound();
+  }
+
+  const isTeacher = classroom.teacherId === session.user.id;
+  const membership = classroom.enrollments.find(
+    (enrollment) => enrollment.student.id === session.user.id
+  );
+
+  if (!isTeacher && !membership) {
+    redirect("/dashboard");
+  }
+
+  const lesson = await prisma.lesson.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      title: true,
+    },
+  });
+
+  if (!lesson) {
+    notFound();
+  }
+
+  const completions = await prisma.lessonCompletion.findMany({
+    where: {
+      classId: classroom.id,
+      lessonId: lesson.id,
+    },
+    select: {
+      studentId: true,
+      completedAt: true,
+    },
+  });
+
+  const completionMap = new Map(
+    completions.map((completion) => [completion.studentId, completion.completedAt])
+  );
+
+  const students = classroom.enrollments
+    .map(({ student }) => {
+      const completedAt = completionMap.get(student.id);
+
+      return {
+        id: student.id,
+        name: student.name ?? student.email,
+        email: student.email,
+        completed: Boolean(completedAt),
+        completedAt,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <section className="space-y-8">
+      <div className="space-y-4">
+        <Button variant="ghost" asChild>
+          <Link href="/dashboard">Back to dashboard</Link>
+        </Button>
+
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">
+            Lesson completion overview
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {lesson.title}
+          </h1>
+          <p className="text-sm text-muted-foreground">Class: {classroom.name}</p>
+        </header>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-border/70 bg-card/70 shadow-sm">
+        <table className="min-w-full divide-y divide-border/60 text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th scope="col" className="px-6 py-3 text-left font-medium text-muted-foreground">
+                Student
+              </th>
+              <th scope="col" className="px-6 py-3 text-left font-medium text-muted-foreground">
+                Email
+              </th>
+              <th scope="col" className="px-6 py-3 text-left font-medium text-muted-foreground">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60 bg-card/50">
+            {students.map((student) => (
+              <tr key={student.id}>
+                <td className="px-6 py-4 font-medium text-foreground">{student.name}</td>
+                <td className="px-6 py-4 text-muted-foreground">{student.email}</td>
+                <td className="px-6 py-4">
+                  {student.completed ? (
+                    <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                      Completed
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700">
+                      Pending
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/page.test.tsx
+++ b/app/(dashboard)/dashboard/page.test.tsx
@@ -3,9 +3,24 @@ import { Role } from "@prisma/client";
 
 import DashboardPage from "./page";
 import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
 vi.mock("@/lib/auth", () => ({
   getServerAuthSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    lesson: {
+      findFirst: vi.fn(),
+    },
+    class: {
+      findFirst: vi.fn(),
+    },
+    classEnrollment: {
+      findFirst: vi.fn(),
+    },
+  },
 }));
 
 vi.mock("next-auth/react", () => ({
@@ -25,6 +40,18 @@ describe("DashboardPage", () => {
         image: null,
       },
     });
+
+    vi.mocked(prisma.lesson.findFirst).mockResolvedValue({
+      slug: "lesson-1-earth-systems-overview",
+      title: "Lesson 1",
+    });
+
+    vi.mocked(prisma.class.findFirst).mockResolvedValue({
+      id: "class-1",
+      name: "NGSS Cohort",
+    });
+
+    vi.mocked(prisma.classEnrollment.findFirst).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -45,8 +72,8 @@ describe("DashboardPage", () => {
     const cards = screen.getAllByRole("article");
     expect(cards).toHaveLength(3);
 
-    expect(screen.getByRole("button", { name: /start a class demo/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /view sprint backlog/i })).toHaveClass("border");
+    expect(screen.getByRole("link", { name: /open lesson 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view completion list/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
   });
 });

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,8 +1,13 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { Role } from "@prisma/client";
+
 import { SignOutButton } from "@/components/features/auth/sign-out-button";
+import { JoinDemoClassButton } from "@/components/features/demo/join-demo-class-button";
 import { Button } from "@/components/ui/button";
 import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
 const highlights = [
   {
@@ -31,6 +36,45 @@ export default async function DashboardPage() {
 
   const displayName = session.user.name ?? "Science Advantage educator";
 
+  const firstLesson = await prisma.lesson.findFirst({
+    orderBy: { order: "asc" },
+    select: {
+      slug: true,
+      title: true,
+    },
+  });
+
+  const classForTeacher =
+    session.user.role === Role.TEACHER
+      ? await prisma.class.findFirst({
+          where: { teacherId: session.user.id },
+          select: { id: true, name: true },
+        })
+      : null;
+
+  const classForStudent =
+    session.user.role === Role.STUDENT
+      ? await prisma.classEnrollment.findFirst({
+          where: { studentId: session.user.id },
+          select: {
+            class: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        })
+      : null;
+
+  const lessonLink = firstLesson ? `/lessons/${firstLesson.slug}` : null;
+  const teacherCompletionsLink =
+    firstLesson && classForTeacher
+      ? `/classes/${classForTeacher.id}/lessons/${firstLesson.slug}/completions`
+      : null;
+  const classSummary =
+    classForTeacher?.name ?? classForStudent?.class.name ?? null;
+
   return (
     <section className="space-y-10">
       <header className="space-y-4">
@@ -42,6 +86,7 @@ export default async function DashboardPage() {
             <h1 className="text-3xl font-semibold tracking-tight">Welcome back, {displayName}</h1>
             <p className="text-sm text-muted-foreground">
               You&apos;re signed in with Google. We&apos;ll replace this placeholder with live class insights as the sprint progresses.
+              {classSummary ? ` Current class: ${classSummary}.` : ""}
             </p>
           </div>
 
@@ -63,10 +108,29 @@ export default async function DashboardPage() {
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
-        <Button size="lg">Start a class demo</Button>
-        <Button variant="outline" size="lg">
-          View sprint backlog
-        </Button>
+        {lessonLink ? (
+          <Button size="lg" asChild>
+            <Link href={lessonLink}>Open Lesson 1</Link>
+          </Button>
+        ) : null}
+        {teacherCompletionsLink ? (
+          <Button variant="outline" size="lg" asChild>
+            <Link href={teacherCompletionsLink}>View completion list</Link>
+          </Button>
+        ) : null}
+        {!lessonLink ? (
+          <Button size="lg" disabled>
+            Lessons loading…
+          </Button>
+        ) : null}
+        {!teacherCompletionsLink && session.user.role === Role.TEACHER ? (
+          <Button variant="outline" size="lg" disabled>
+            No class yet
+          </Button>
+        ) : null}
+        {!classForStudent && session.user.role === Role.STUDENT ? (
+          <JoinDemoClassButton />
+        ) : null}
       </div>
     </section>
   );

--- a/app/(dashboard)/lessons/[slug]/page.tsx
+++ b/app/(dashboard)/lessons/[slug]/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { LessonCompletionToggle } from "@/components/features/lessons/lesson-completion-toggle";
+import { LessonContent } from "@/components/features/lessons/lesson-content";
+import { JoinDemoClassButton } from "@/components/features/demo/join-demo-class-button";
+import { Button } from "@/components/ui/button";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type LessonPageProps = {
+  params: {
+    slug: string;
+  } | Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function LessonPage({ params }: LessonPageProps) {
+  const { slug } = await Promise.resolve(params);
+
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  const lesson = await prisma.lesson.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      title: true,
+      summary: true,
+      content: true,
+    },
+  });
+
+  if (!lesson) {
+    notFound();
+  }
+
+  const enrollment = await prisma.classEnrollment.findFirst({
+    where: {
+      studentId: session.user.id,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+    select: {
+      classId: true,
+      class: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  const completion = enrollment
+    ? await prisma.lessonCompletion.findUnique({
+        where: {
+          lessonId_studentId_classId: {
+            lessonId: lesson.id,
+            studentId: session.user.id,
+            classId: enrollment.classId,
+          },
+        },
+        select: {
+          completedAt: true,
+        },
+      })
+    : null;
+
+  const hasEnrollment = Boolean(enrollment);
+
+  return (
+    <section className="space-y-8">
+      <div className="space-y-4">
+        <Button variant="ghost" asChild>
+          <Link href="/dashboard">Back to dashboard</Link>
+        </Button>
+
+        <header className="space-y-3">
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">
+            Lesson viewer
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight">{lesson.title}</h1>
+          {lesson.summary ? (
+            <p className="text-base text-muted-foreground">{lesson.summary}</p>
+          ) : null}
+          {hasEnrollment ? (
+            <div className="space-y-3">
+              <LessonCompletionToggle
+                lessonSlug={slug}
+                classContext={enrollment?.class ?? null}
+                initialCompleted={Boolean(completion)}
+              />
+              {enrollment?.class ? (
+                <Button variant="outline" size="sm" asChild>
+                  <Link
+                    href={`/classes/${enrollment.class.id}/lessons/${slug}/completions`}
+                  >
+                    View class completion list
+                  </Link>
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Join the demo class to track your completion status.
+              </p>
+              <JoinDemoClassButton />
+            </div>
+          )}
+        </header>
+      </div>
+
+      <LessonContent content={lesson.content} />
+    </section>
+  );
+}

--- a/app/api/classes/[classId]/lessons/[slug]/completions/route.ts
+++ b/app/api/classes/[classId]/lessons/[slug]/completions/route.ts
@@ -1,0 +1,121 @@
+import { Role } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteContext = {
+  params:
+    | {
+        classId: string;
+        slug: string;
+      }
+    | Promise<{
+        classId: string;
+        slug: string;
+      }>;
+};
+
+export async function GET(_: Request, { params }: RouteContext) {
+  const { classId, slug } = await Promise.resolve(params);
+
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const classroom = await prisma.class.findUnique({
+    where: {
+      id: classId,
+    },
+    select: {
+      id: true,
+      name: true,
+      teacherId: true,
+    },
+  });
+
+  if (!classroom) {
+    return NextResponse.json({ error: "Class not found" }, { status: 404 });
+  }
+
+  const isTeacher = classroom.teacherId === session.user.id;
+
+  if (!isTeacher) {
+    const membership = await prisma.classEnrollment.findFirst({
+      where: {
+        classId: classroom.id,
+        studentId: session.user.id,
+      },
+      select: { id: true },
+    });
+
+    if (!membership) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const lesson = await prisma.lesson.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      title: true,
+    },
+  });
+
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+
+  const enrollments = await prisma.classEnrollment.findMany({
+    where: { classId: classroom.id },
+    include: {
+      student: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+  });
+
+  const completions = await prisma.lessonCompletion.findMany({
+    where: {
+      classId: classroom.id,
+      lessonId: lesson.id,
+    },
+    select: {
+      studentId: true,
+      completedAt: true,
+    },
+  });
+
+  const completionMap = new Map(
+    completions.map((completion) => [completion.studentId, completion.completedAt])
+  );
+
+  const students = enrollments
+    .map((enrollment) => {
+      const completedAt = completionMap.get(enrollment.student.id);
+
+      return {
+        studentId: enrollment.student.id,
+        name: enrollment.student.name ?? enrollment.student.email,
+        email: enrollment.student.email,
+        completed: Boolean(completedAt),
+        completedAt: completedAt ? completedAt.toISOString() : null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return NextResponse.json({
+    class: {
+      id: classroom.id,
+      name: classroom.name,
+    },
+    lesson,
+    students,
+  });
+}

--- a/app/api/demo/join/route.ts
+++ b/app/api/demo/join/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteContext = {
+  params: Record<string, never>;
+};
+
+export async function POST(_: Request, __: RouteContext) {
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const classroom = await prisma.class.findFirst({
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  if (!classroom) {
+    return NextResponse.json(
+      { error: "No demo class configured" },
+      { status: 400 }
+    );
+  }
+
+  const enrollment = await prisma.classEnrollment.upsert({
+    where: {
+      classId_studentId: {
+        classId: classroom.id,
+        studentId: session.user.id,
+      },
+    },
+    update: {},
+    create: {
+      classId: classroom.id,
+      studentId: session.user.id,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return NextResponse.json({
+    classId: classroom.id,
+    className: classroom.name,
+    enrollmentId: enrollment.id,
+  });
+}

--- a/app/api/lessons/[slug]/completion/route.ts
+++ b/app/api/lessons/[slug]/completion/route.ts
@@ -1,0 +1,200 @@
+import { Role } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type RouteContext = {
+  params:
+    | {
+        slug: string;
+      }
+    | Promise<{
+        slug: string;
+      }>;
+};
+
+async function resolveClassContext(userId: string, role: Role, classId?: string) {
+  if (classId) {
+    const enrollment = await prisma.classEnrollment.findFirst({
+      where: {
+        classId,
+        studentId: userId,
+      },
+      select: {
+        classId: true,
+        class: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!enrollment) {
+      return null;
+    }
+
+    return enrollment.class;
+  }
+
+  const enrollment = await prisma.classEnrollment.findFirst({
+    where: {
+      studentId: userId,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+    select: {
+      classId: true,
+      class: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return enrollment?.class ?? null;
+}
+
+export async function GET(_: Request, { params }: RouteContext) {
+  const { slug } = await Promise.resolve(params);
+
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const lesson = await prisma.lesson.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      title: true,
+      summary: true,
+      content: true,
+    },
+  });
+
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+
+  const classContext = await resolveClassContext(session.user.id, session.user.role);
+
+  let completion: { completed: boolean; completedAt?: string } = { completed: false };
+
+  if (classContext) {
+    const existing = await prisma.lessonCompletion.findUnique({
+      where: {
+        lessonId_studentId_classId: {
+          lessonId: lesson.id,
+          studentId: session.user.id,
+          classId: classContext.id,
+        },
+      },
+      select: {
+        completedAt: true,
+      },
+    });
+
+    if (existing) {
+      completion = {
+        completed: true,
+        completedAt: existing.completedAt.toISOString(),
+      };
+    }
+  }
+
+  return NextResponse.json({
+    lesson,
+    classContext,
+    completion,
+  });
+}
+
+export async function POST(request: Request, { params }: RouteContext) {
+  const { slug } = await Promise.resolve(params);
+
+  const session = await getServerAuthSession();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const lesson = await prisma.lesson.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+
+  const body = await request.json().catch(() => null);
+
+  if (!body || typeof body.completed !== "boolean") {
+    return NextResponse.json(
+      { error: "Invalid payload" },
+      { status: 400 }
+    );
+  }
+
+  const classContext = await resolveClassContext(session.user.id, session.user.role, body.classId);
+
+  if (!classContext) {
+    return NextResponse.json(
+      { error: "No class context for completion" },
+      { status: 400 }
+    );
+  }
+
+  if (body.completed) {
+    const completion = await prisma.lessonCompletion.upsert({
+      where: {
+        lessonId_studentId_classId: {
+          lessonId: lesson.id,
+          studentId: session.user.id,
+          classId: classContext.id,
+        },
+      },
+      create: {
+        lessonId: lesson.id,
+        studentId: session.user.id,
+        classId: classContext.id,
+      },
+      update: {
+        completedAt: new Date(),
+      },
+      select: {
+        completedAt: true,
+      },
+    });
+
+    return NextResponse.json({
+      classContext,
+      completion: {
+        completed: true,
+        completedAt: completion.completedAt.toISOString(),
+      },
+    });
+  }
+
+  await prisma.lessonCompletion.deleteMany({
+    where: {
+      lessonId: lesson.id,
+      studentId: session.user.id,
+      classId: classContext.id,
+    },
+  });
+
+  return NextResponse.json({
+    classContext,
+    completion: {
+      completed: false,
+    },
+  });
+}

--- a/components/features/demo/join-demo-class-button.tsx
+++ b/components/features/demo/join-demo-class-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+type JoinDemoClassButtonProps = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+export function JoinDemoClassButton({
+  className,
+  children = "Join demo class",
+}: JoinDemoClassButtonProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const handleJoin = () => {
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/demo/join", {
+          method: "POST",
+        });
+
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+
+          throw new Error(payload?.error ?? "Unable to join class");
+        }
+
+        router.refresh();
+      } catch (exception) {
+        setError(
+          exception instanceof Error ? exception.message : "Unable to join class"
+        );
+      }
+    });
+  };
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <Button type="button" size="sm" onClick={handleJoin} disabled={isPending}>
+        {isPending ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Joining…
+          </>
+        ) : (
+          children
+        )}
+      </Button>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/components/features/lessons/lesson-completion-toggle.test.tsx
+++ b/components/features/lessons/lesson-completion-toggle.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LessonCompletionToggle } from "./lesson-completion-toggle";
+
+describe("LessonCompletionToggle", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the initial completion state", () => {
+    render(
+      <LessonCompletionToggle
+        lessonSlug="lesson-1"
+        classContext={{ id: "class-1", name: "NGSS Cohort" }}
+        initialCompleted
+      />
+    );
+
+    expect(screen.getByText("Marked complete")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark incomplete" })).toBeInTheDocument();
+    expect(screen.getByText(/Completion for NGSS Cohort/)).toBeInTheDocument();
+  });
+
+  it("toggles completion state after a successful update", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          completion: { completed: true },
+          classContext: { id: "class-1", name: "NGSS Cohort" },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    render(
+      <LessonCompletionToggle
+        lessonSlug="lesson-1"
+        classContext={{ id: "class-1", name: "NGSS Cohort" }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Mark complete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Marked complete")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Mark incomplete" })).toBeEnabled();
+    });
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/lessons/lesson-1/completion");
+    expect(options?.method).toBe("POST");
+    expect(JSON.parse((options?.body as string) ?? "{}")).toEqual({
+      completed: true,
+      classId: "class-1",
+    });
+  });
+
+  it("disables the toggle when no class context exists", async () => {
+    const user = userEvent.setup();
+
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    render(<LessonCompletionToggle lessonSlug="lesson-1" />);
+
+    const button = screen.getByRole("button", { name: "Mark complete" });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error if the update fails", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "No class context for completion" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    render(
+      <LessonCompletionToggle
+        lessonSlug="lesson-1"
+        classContext={{ id: "class-1", name: "NGSS Cohort" }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Mark complete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No class context for completion")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/features/lessons/lesson-completion-toggle.tsx
+++ b/components/features/lessons/lesson-completion-toggle.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
+
+type LessonCompletionToggleProps = {
+  lessonSlug: string;
+  classContext?: {
+    id: string;
+    name: string;
+  } | null;
+  initialCompleted?: boolean;
+};
+
+export function LessonCompletionToggle({
+  lessonSlug,
+  classContext,
+  initialCompleted = false,
+}: LessonCompletionToggleProps) {
+  const [context, setContext] = useState(classContext ?? null);
+  const [completed, setCompleted] = useState(initialCompleted);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const actionLabel = completed ? "Mark incomplete" : "Mark complete";
+
+  const handleToggle = () => {
+    if (!context) {
+      setError("Ask your teacher to add you to a class before marking completion.");
+      return;
+    }
+
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/lessons/${lessonSlug}/completion`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            completed: !completed,
+            classId: context?.id,
+          }),
+        });
+
+        let payload: {
+          completion?: { completed: boolean };
+          classContext?: { id: string; name: string } | null;
+          error?: string;
+        } | null = null;
+
+        try {
+          payload = (await response.json()) as typeof payload;
+        } catch (parseError) {
+          payload = null;
+        }
+
+        if (!response.ok || !payload?.completion) {
+          throw new Error(payload?.error ?? "Failed to update completion");
+        }
+
+        setCompleted(payload.completion.completed);
+
+        if (payload.classContext !== undefined) {
+          setContext(payload.classContext ?? null);
+        }
+      } catch (exception) {
+        setError(
+          exception instanceof Error
+            ? exception.message
+            : "Unable to update completion"
+        );
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">
+            {context ? `Completion for ${context.name}` : "Completion"}
+          </p>
+          <p className={cn("text-sm", completed ? "text-emerald-600" : "text-muted-foreground")}>
+            {completed ? "Marked complete" : "Not yet completed"}
+          </p>
+        </div>
+
+        <Button
+          onClick={handleToggle}
+          disabled={isPending || !context}
+          variant={completed ? "outline" : "default"}
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving…
+            </>
+          ) : (
+            actionLabel
+          )}
+        </Button>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/components/features/lessons/lesson-content.test.tsx
+++ b/components/features/lessons/lesson-content.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+
+import { LessonContent } from "./lesson-content";
+
+describe("LessonContent", () => {
+  it("renders lesson markdown as preformatted text", () => {
+    const content = "## Title\n- Item one\n- Item two";
+
+    render(<LessonContent content={content} />);
+
+    expect(screen.getByText("## Title", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("- Item one", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("- Item two", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/components/features/lessons/lesson-content.tsx
+++ b/components/features/lessons/lesson-content.tsx
@@ -1,0 +1,17 @@
+import { memo } from "react";
+
+type LessonContentProps = {
+  content: string;
+};
+
+function LessonContentComponent({ content }: LessonContentProps) {
+  return (
+    <article className="rounded-2xl border border-border/70 bg-card/70 p-6 shadow-sm">
+      <pre className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+        {content}
+      </pre>
+    </article>
+  );
+}
+
+export const LessonContent = memo(LessonContentComponent);

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,5 +10,5 @@ export default withAuth({
 });
 
 export const config = {
-  matcher: ["/dashboard", "/dashboard/:path*"],
+  matcher: ["/dashboard", "/dashboard/:path*", "/lessons/:path*", "/classes/:path*"],
 };

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "format:write": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "echo \"Integration tests not yet implemented\"",
-    "test:e2e": "echo \"E2E tests not yet implemented\""
+    "test:integration": "vitest run --dir tests/integration",
+    "test:e2e": "vitest run --dir tests/e2e"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   classes       Class[]           @relation("ClassTeacher")
   enrollments   ClassEnrollment[]
   attempts      Attempt[]
+  lessonCompletions LessonCompletion[]
   accounts      Account[]
   sessions      Session[]
   createdAt     DateTime          @default(now())
@@ -42,6 +43,7 @@ model Class {
   teacher     User              @relation("ClassTeacher", fields: [teacherId], references: [id])
   teacherId   String
   enrollments ClassEnrollment[]
+  lessonCompletions LessonCompletion[]
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
 }
@@ -68,6 +70,7 @@ model Lesson {
   type          LessonType     @default(LESSON)
   quizQuestions QuizQuestion[]
   attempts      Attempt[]
+  completions   LessonCompletion[]
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 }
@@ -101,6 +104,22 @@ model Attempt {
 
   @@index([studentId])
   @@index([lessonId])
+}
+
+model LessonCompletion {
+  id          String   @id @default(cuid())
+  lesson      Lesson   @relation(fields: [lessonId], references: [id])
+  lessonId    String
+  student     User     @relation(fields: [studentId], references: [id])
+  studentId   String
+  class       Class    @relation(fields: [classId], references: [id])
+  classId     String
+  completedAt DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([lessonId, studentId, classId])
+  @@index([classId])
+  @@index([studentId])
 }
 
 model Account {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -306,6 +306,7 @@ const lessons: LessonSeed[] = [
 ];
 
 async function resetForSeed() {
+  await prisma.lessonCompletion.deleteMany();
   await prisma.attempt.deleteMany();
   await prisma.quizQuestion.deleteMany();
   await prisma.lesson.deleteMany();
@@ -342,7 +343,7 @@ async function main() {
     }),
   ]);
 
-  await prisma.class.create({
+  const classroom = await prisma.class.create({
     data: {
       name: "NGSS Grade 6 - Unit 1",
       description: "Pilot cohort focusing on Earth's systems, weather, and climate.",
@@ -358,7 +359,7 @@ async function main() {
     },
   });
 
-  await prisma.$transaction(
+  const createdLessons = await prisma.$transaction(
     lessons.map((lesson) =>
       prisma.lesson.create({
         data: {
@@ -383,6 +384,20 @@ async function main() {
     )
   );
 
+  const lessonOne = createdLessons.find(
+    (lesson) => lesson.slug === "lesson-1-earth-systems-overview"
+  );
+
+  if (lessonOne) {
+    await prisma.lessonCompletion.create({
+      data: {
+        lessonId: lessonOne.id,
+        studentId: students[0].id,
+        classId: classroom.id,
+      },
+    });
+  }
+
   const totalQuestions = lessons.reduce((sum, lesson) => sum + lesson.quiz.length, 0);
 
   console.log("Seeded:", {
@@ -391,6 +406,7 @@ async function main() {
     classes: 1,
     lessons: lessons.length,
     questions: totalQuestions,
+    lessonCompletions: lessonOne ? 1 : 0,
   });
 }
 

--- a/tests/e2e/lesson-completion-flow.test.ts
+++ b/tests/e2e/lesson-completion-flow.test.ts
@@ -1,0 +1,233 @@
+import { Role } from "@prisma/client";
+
+import { GET as getLessonCompletion, POST } from "@/app/api/lessons/[slug]/completion/route";
+import { GET as getClassCompletions } from "@/app/api/classes/[classId]/lessons/[slug]/completions/route";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/auth", () => ({
+  getServerAuthSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    lesson: {
+      findUnique: vi.fn(),
+    },
+    classEnrollment: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    lessonCompletion: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+    class: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("Lesson completion end-to-end", () => {
+  const db = {
+    lessons: [
+      {
+        id: "lesson-1",
+        slug: "lesson-1-earth-systems-overview",
+        title: "Lesson 1",
+        summary: "",
+        content: "content",
+      },
+    ],
+    classes: [
+      {
+        id: "class-1",
+        name: "NGSS Cohort",
+        teacherId: "teacher-1",
+      },
+    ],
+    enrollments: [
+      {
+        classId: "class-1",
+        studentId: "student-1",
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      },
+    ],
+    completions: [] as Array<{
+      lessonId: string;
+      studentId: string;
+      classId: string;
+      completedAt: Date;
+    }>,
+  };
+
+  beforeEach(() => {
+    db.completions.length = 0;
+
+    (prisma.lesson.findUnique as vi.Mock).mockImplementation(async ({ where }: { where: { slug: string } }) =>
+      db.lessons.find((lesson) => lesson.slug === where.slug) ?? null
+    );
+
+    (prisma.classEnrollment.findFirst as vi.Mock).mockImplementation(
+      async ({ where }: { where: { studentId: string; classId?: string } }) => {
+        const enrollment = db.enrollments.find((entry) => {
+          if (where.classId) {
+            return entry.studentId === where.studentId && entry.classId === where.classId;
+          }
+
+          return entry.studentId === where.studentId;
+        });
+
+        if (!enrollment) {
+          return null;
+        }
+
+        const classroom = db.classes.find((klass) => klass.id === enrollment.classId);
+
+        if (!classroom) {
+          return null;
+        }
+
+        return {
+          classId: enrollment.classId,
+          class: {
+            id: classroom.id,
+            name: classroom.name,
+          },
+        };
+      }
+    );
+
+    (prisma.lessonCompletion.findUnique as vi.Mock).mockImplementation(
+      async ({ where }: { where: { lessonId_studentId_classId: { lessonId: string; studentId: string; classId: string } } }) =>
+        db.completions.find(
+          (completion) =>
+            completion.lessonId === where.lessonId_studentId_classId.lessonId &&
+            completion.studentId === where.lessonId_studentId_classId.studentId &&
+            completion.classId === where.lessonId_studentId_classId.classId
+        ) ?? null
+    );
+
+    (prisma.lessonCompletion.upsert as vi.Mock).mockImplementation(
+      async ({ where, create }: { where: { lessonId_studentId_classId: { lessonId: string; studentId: string; classId: string } }; create: { lessonId: string; studentId: string; classId: string } }) => {
+        let existing = db.completions.find(
+          (completion) =>
+            completion.lessonId === where.lessonId_studentId_classId.lessonId &&
+            completion.studentId === where.lessonId_studentId_classId.studentId &&
+            completion.classId === where.lessonId_studentId_classId.classId
+        );
+
+        if (!existing) {
+          existing = {
+            lessonId: create.lessonId,
+            studentId: create.studentId,
+            classId: create.classId,
+            completedAt: new Date(),
+          };
+          db.completions.push(existing);
+        } else {
+          existing.completedAt = new Date();
+        }
+
+        return { completedAt: existing.completedAt };
+      }
+    );
+
+    (prisma.lessonCompletion.deleteMany as vi.Mock).mockImplementation(
+      async ({ where }: { where: { lessonId: string; studentId: string; classId: string } }) => {
+        const before = db.completions.length;
+        db.completions = db.completions.filter(
+          (completion) =>
+            !(
+              completion.lessonId === where.lessonId &&
+              completion.studentId === where.studentId &&
+              completion.classId === where.classId
+            )
+        );
+
+        return { count: before - db.completions.length };
+      }
+    );
+
+    (prisma.class.findFirst as vi.Mock).mockImplementation(
+      async ({ where }: { where: { id: string; teacherId: string } }) =>
+        db.classes.find((klass) => klass.id === where.id && klass.teacherId === where.teacherId) ?? null
+    );
+
+    (prisma.class.findUnique as vi.Mock).mockImplementation(
+      async ({ where }: { where: { id: string } }) =>
+        db.classes.find((klass) => klass.id === where.id) ?? null
+    );
+
+    (prisma.classEnrollment.findMany as vi.Mock).mockImplementation(
+      async ({ where }: { where: { classId: string } }) =>
+        db.enrollments
+          .filter((enrollment) => enrollment.classId === where.classId)
+          .map((enrollment) => {
+            const student = enrollment.studentId === "student-1"
+              ? { id: "student-1", name: "Avery", email: "avery@example.com" }
+              : { id: enrollment.studentId, name: `Student ${enrollment.studentId}`, email: `${enrollment.studentId}@example.com` };
+
+            return { student };
+          })
+    );
+
+    (prisma.lessonCompletion.findMany as vi.Mock).mockImplementation(
+      async ({ where }: { where: { classId: string; lessonId: string } }) =>
+        db.completions.filter(
+          (completion) => completion.classId === where.classId && completion.lessonId === where.lessonId
+        )
+    );
+  });
+
+  it("persists student completion and surfaces it to the teacher", async () => {
+    (getServerAuthSession as vi.Mock).mockResolvedValue({
+      user: { id: "student-1", role: Role.STUDENT },
+    });
+
+    const initialStudentView = await getLessonCompletion(new Request("http://localhost/api"), {
+      params: { slug: "lesson-1-earth-systems-overview" },
+    });
+
+    expect(db.completions).toHaveLength(0);
+
+    const initialPayload = await initialStudentView.json();
+    expect(initialPayload.completion.completed).toBe(false);
+
+    await POST(
+      new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completed: true, classId: "class-1" }),
+      }),
+      {
+        params: { slug: "lesson-1-earth-systems-overview" },
+      }
+    );
+
+    expect(db.completions).toHaveLength(1);
+
+    (getServerAuthSession as vi.Mock).mockResolvedValue({
+      user: { id: "teacher-1", role: Role.TEACHER },
+    });
+
+    const teacherView = await getClassCompletions(new Request("http://localhost/api"), {
+      params: { classId: "class-1", slug: "lesson-1-earth-systems-overview" },
+    });
+
+    const teacherPayload = await teacherView.json();
+
+    expect(teacherPayload.students).toEqual([
+      {
+        studentId: "student-1",
+        name: "Avery",
+        email: "avery@example.com",
+        completed: true,
+        completedAt: expect.any(String),
+      },
+    ]);
+  });
+});

--- a/tests/integration/class-lesson-completions-route.test.ts
+++ b/tests/integration/class-lesson-completions-route.test.ts
@@ -1,0 +1,123 @@
+import { Role } from "@prisma/client";
+
+import { GET } from "@/app/api/classes/[classId]/lessons/[slug]/completions/route";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/auth", () => ({
+  getServerAuthSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    class: {
+      findUnique: vi.fn(),
+    },
+    lesson: {
+      findUnique: vi.fn(),
+    },
+    classEnrollment: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    lessonCompletion: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("Class lesson completions route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("requires a teacher session", async () => {
+    (getServerAuthSession as vi.Mock).mockResolvedValue({
+      user: { id: "student-1", role: Role.STUDENT },
+    });
+
+    (prisma.class.findUnique as vi.Mock).mockResolvedValue({
+      id: "class-1",
+      name: "NGSS Cohort",
+      teacherId: "teacher-1",
+    });
+
+    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValue(null);
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: { classId: "class-1", slug: "lesson-1" },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns aggregated completion data", async () => {
+    (getServerAuthSession as vi.Mock).mockResolvedValue({
+      user: { id: "teacher-1", role: Role.TEACHER },
+    });
+
+    (prisma.class.findUnique as vi.Mock).mockResolvedValue({
+      id: "class-1",
+      name: "NGSS Cohort",
+      teacherId: "teacher-1",
+    });
+
+    (prisma.lesson.findUnique as vi.Mock).mockResolvedValue({
+      id: "lesson-1",
+      title: "Earth systems",
+    });
+
+    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValue({ id: "enroll-1" });
+
+    (prisma.classEnrollment.findMany as vi.Mock).mockResolvedValue([
+      {
+        student: {
+          id: "student-1",
+          name: "Avery",
+          email: "avery@example.com",
+        },
+      },
+      {
+        student: {
+          id: "student-2",
+          name: "Jordan",
+          email: "jordan@example.com",
+        },
+      },
+    ]);
+
+    (prisma.lessonCompletion.findMany as vi.Mock).mockResolvedValue([
+      {
+        studentId: "student-2",
+        completedAt: new Date("2024-01-02T00:00:00.000Z"),
+      },
+    ]);
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: { classId: "class-1", slug: "lesson-1" },
+    });
+
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+
+    expect(payload.class.name).toBe("NGSS Cohort");
+    expect(payload.lesson.title).toBe("Earth systems");
+    expect(payload.students).toEqual([
+      {
+        studentId: "student-1",
+        name: "Avery",
+        email: "avery@example.com",
+        completed: false,
+        completedAt: null,
+      },
+      {
+        studentId: "student-2",
+        name: "Jordan",
+        email: "jordan@example.com",
+        completed: true,
+        completedAt: new Date("2024-01-02T00:00:00.000Z").toISOString(),
+      },
+    ]);
+  });
+});

--- a/tests/integration/lesson-completion-route.test.ts
+++ b/tests/integration/lesson-completion-route.test.ts
@@ -1,0 +1,185 @@
+import { Role } from "@prisma/client";
+
+import { GET, POST } from "@/app/api/lessons/[slug]/completion/route";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/auth", () => ({
+  getServerAuthSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    lesson: {
+      findUnique: vi.fn(),
+    },
+    classEnrollment: {
+      findFirst: vi.fn(),
+    },
+    lessonCompletion: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+describe("Lesson completion route", () => {
+  const session = {
+    user: {
+      id: "student-1",
+      role: Role.STUDENT,
+      email: "student@example.com",
+      name: "Student One",
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (getServerAuthSession as vi.Mock).mockResolvedValue(session);
+
+    (prisma.lesson.findUnique as vi.Mock).mockResolvedValue({
+      id: "lesson-1",
+      title: "Lesson title",
+      summary: null,
+      content: "content",
+    });
+
+    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValue({
+      classId: "class-1",
+      class: {
+        id: "class-1",
+        name: "NGSS Cohort",
+      },
+    });
+
+  });
+
+  it("returns lesson data and completion state", async () => {
+    const completedAt = new Date("2024-01-01T00:00:00.000Z");
+
+    (prisma.lessonCompletion.findUnique as vi.Mock).mockResolvedValue({
+      completedAt,
+    });
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: { slug: "lesson-1" },
+    });
+
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+
+    expect(payload.lesson.title).toBe("Lesson title");
+    expect(payload.classContext).toEqual({ id: "class-1", name: "NGSS Cohort" });
+    expect(payload.completion).toEqual({
+      completed: true,
+      completedAt: completedAt.toISOString(),
+    });
+  });
+
+  it("creates a completion when toggled on", async () => {
+    const completedAt = new Date("2024-05-01T12:00:00.000Z");
+
+    (prisma.lesson.findUnique as vi.Mock).mockResolvedValueOnce({ id: "lesson-1" });
+    (prisma.lessonCompletion.upsert as vi.Mock).mockResolvedValue({
+      completedAt,
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ completed: true, classId: "class-1" }),
+      }),
+      {
+        params: { slug: "lesson-1" },
+      }
+    );
+
+    expect(prisma.lessonCompletion.upsert).toHaveBeenCalledWith({
+      where: {
+        lessonId_studentId_classId: {
+          lessonId: "lesson-1",
+          studentId: "student-1",
+          classId: "class-1",
+        },
+      },
+      create: {
+        lessonId: "lesson-1",
+        studentId: "student-1",
+        classId: "class-1",
+      },
+      update: {
+        completedAt: expect.any(Date),
+      },
+      select: {
+        completedAt: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+
+    expect(payload.completion.completed).toBe(true);
+    expect(payload.classContext).toEqual({ id: "class-1", name: "NGSS Cohort" });
+  });
+
+  it("removes a completion when toggled off", async () => {
+    (prisma.lesson.findUnique as vi.Mock).mockResolvedValueOnce({ id: "lesson-1" });
+
+    const response = await POST(
+      new Request("http://localhost/api", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ completed: false, classId: "class-1" }),
+      }),
+      {
+        params: { slug: "lesson-1" },
+      }
+    );
+
+    expect(prisma.lessonCompletion.deleteMany).toHaveBeenCalledWith({
+      where: {
+        lessonId: "lesson-1",
+        studentId: "student-1",
+        classId: "class-1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+
+    expect(payload.completion.completed).toBe(false);
+    expect(payload.classContext).toEqual({ id: "class-1", name: "NGSS Cohort" });
+  });
+
+  it("returns an error when no class context is found", async () => {
+    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValueOnce(null);
+
+    const response = await POST(
+      new Request("http://localhost/api", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ completed: true }),
+      }),
+      {
+        params: { slug: "lesson-1" },
+      }
+    );
+
+    expect(response.status).toBe(400);
+
+    const payload = await response.json();
+
+    expect(payload.error).toBe("No class context for completion");
+  });
+});


### PR DESCRIPTION
## Summary\n- add student lesson viewer with completion toggle and content\n- expose demo join helper plus teacher/student completion views\n- seed lesson data and add tests covering UI, API, and end-to-end flows\n- filed Issue #14 to replace the demo join with real access control\n\n## Testing\n- npm run test\n- npm run test:integration\n- npm run test:e2e\n