### PR TITLE
fix: restrict lesson completion reports to teachers

### DIFF
--- a/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.test.tsx
+++ b/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import { Role } from "@prisma/client";
+
+import LessonCompletionListPage from "./page";
+import { getServerAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getServerAuthSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    class: {
+      findUnique: vi.fn(),
+    },
+    lesson: {
+      findUnique: vi.fn(),
+    },
+    lessonCompletion: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("LessonCompletionListPage", () => {
+  const mockGetServerAuthSession = vi.mocked(getServerAuthSession);
+  const mockRedirect = vi.mocked(redirect);
+  const mockNotFound = vi.mocked(notFound);
+
+  beforeEach(() => {
+    mockRedirect.mockReset();
+    mockRedirect.mockImplementation((path: string) => {
+      const error = new Error(`REDIRECT:${path}`);
+      // mimic Next.js redirect error shape for consistency
+      (error as Error & { digest?: string }).digest = "NEXT_REDIRECT";
+      throw error;
+    });
+
+    mockNotFound.mockReset();
+    mockNotFound.mockImplementation(() => {
+      const error = new Error("NOT_FOUND");
+      (error as Error & { digest?: string }).digest = "NEXT_NOT_FOUND";
+      throw error;
+    });
+
+    mockGetServerAuthSession.mockResolvedValue({
+      user: {
+        id: "teacher-1",
+        role: Role.TEACHER,
+        email: "teacher@example.com",
+        name: "Taylor Teacher",
+      },
+    });
+
+    (prisma.class.findUnique as vi.Mock).mockResolvedValue({
+      id: "class-1",
+      name: "NGSS Cohort",
+      teacherId: "teacher-1",
+      enrollments: [
+        {
+          student: {
+            id: "student-1",
+            name: "Avery Student",
+            email: "avery@example.com",
+          },
+        },
+        {
+          student: {
+            id: "student-2",
+            name: "Jordan Student",
+            email: "jordan@example.com",
+          },
+        },
+      ],
+    });
+
+    (prisma.lesson.findUnique as vi.Mock).mockResolvedValue({
+      id: "lesson-1",
+      title: "Earth Systems",
+    });
+
+    (prisma.lessonCompletion.findMany as vi.Mock).mockResolvedValue([
+      {
+        studentId: "student-2",
+        completedAt: new Date("2024-01-02T00:00:00.000Z"),
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects non-teacher users to the dashboard", async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: {
+        id: "student-1",
+        role: Role.STUDENT,
+        email: "student@example.com",
+        name: "Sam Student",
+      },
+    });
+
+    await expect(
+      LessonCompletionListPage({
+        params: { classId: "class-1", slug: "lesson-1" },
+      })
+    ).rejects.toThrow("REDIRECT:/dashboard");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("renders completion status for teachers", async () => {
+    const Page = await LessonCompletionListPage({
+      params: { classId: "class-1", slug: "lesson-1" },
+    });
+
+    render(Page);
+
+    expect(
+      screen.getByRole("heading", { name: /earth systems/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/class:\s+ngss cohort/i)).toBeInTheDocument();
+    expect(screen.getByText("Avery Student")).toBeInTheDocument();
+    expect(screen.getByText("Jordan Student")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.tsx
+++ b/app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.tsx
@@ -55,11 +55,8 @@ export default async function LessonCompletionListPage({
   }
 
   const isTeacher = classroom.teacherId === session.user.id;
-  const membership = classroom.enrollments.find(
-    (enrollment) => enrollment.student.id === session.user.id
-  );
 
-  if (!isTeacher && !membership) {
+  if (!isTeacher) {
     redirect("/dashboard");
   }
 

--- a/app/(dashboard)/dashboard/page.test.tsx
+++ b/app/(dashboard)/dashboard/page.test.tsx
@@ -76,4 +76,31 @@ describe("DashboardPage", () => {
     expect(screen.getByRole("link", { name: /view completion list/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
   });
+
+  it("hides teacher-only completion reports from students", async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: {
+        id: "student_456",
+        role: Role.STUDENT,
+        name: "Sky Student",
+        email: "sky@example.com",
+        image: null,
+      },
+    });
+
+    vi.mocked(prisma.class.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.classEnrollment.findFirst).mockResolvedValue({
+      class: {
+        id: "class-123",
+        name: "Demo Class",
+      },
+    });
+
+    const Page = await DashboardPage();
+    render(Page);
+
+    expect(
+      screen.queryByRole("link", { name: /view completion list/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/app/(dashboard)/lessons/[slug]/page.tsx
+++ b/app/(dashboard)/lessons/[slug]/page.tsx
@@ -170,7 +170,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
       })
     : null;
 
-  const hasEnrollment = Boolean(enrollment);
+  const hasStudentEnrollment = Boolean(enrollment) && !isTeacher;
 
   const experimentSubmission =
     isExperiment && !isTeacher && enrollment
@@ -218,22 +218,13 @@ export default async function LessonPage({ params }: LessonPageProps) {
           {lesson.summary ? (
             <p className="text-base text-muted-foreground">{lesson.summary}</p>
           ) : null}
-          {hasEnrollment ? (
+          {hasStudentEnrollment ? (
             <div className="space-y-3">
               <LessonCompletionToggle
                 lessonSlug={slug}
                 classContext={enrollment?.class ?? null}
                 initialCompleted={Boolean(completion)}
               />
-              {enrollment?.class ? (
-                <Button variant="outline" size="sm" asChild>
-                  <Link
-                    href={`/classes/${enrollment.class.id}/lessons/${slug}/completions`}
-                  >
-                    View class completion list
-                  </Link>
-                </Button>
-              ) : null}
             </div>
           ) : isTeacher ? (
             <div className="space-y-3">

--- a/app/api/classes/[classId]/lessons/[slug]/completions/route.ts
+++ b/app/api/classes/[classId]/lessons/[slug]/completions/route.ts
@@ -42,17 +42,7 @@ export async function GET(_: Request, { params }: RouteContext) {
   const isTeacher = classroom.teacherId === session.user.id;
 
   if (!isTeacher) {
-    const membership = await prisma.classEnrollment.findFirst({
-      where: {
-        classId: classroom.id,
-        studentId: session.user.id,
-      },
-      select: { id: true },
-    });
-
-    if (!membership) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const lesson = await prisma.lesson.findUnique({

--- a/tests/integration/class-lesson-completions-route.test.ts
+++ b/tests/integration/class-lesson-completions-route.test.ts
@@ -31,7 +31,7 @@ describe("Class lesson completions route", () => {
     vi.resetAllMocks();
   });
 
-  it("requires a teacher session", async () => {
+  it("rejects non-teacher sessions", async () => {
     (getServerAuthSession as vi.Mock).mockResolvedValue({
       user: { id: "student-1", role: Role.STUDENT },
     });
@@ -41,8 +41,6 @@ describe("Class lesson completions route", () => {
       name: "NGSS Cohort",
       teacherId: "teacher-1",
     });
-
-    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValue(null);
 
     const response = await GET(new Request("http://localhost/api"), {
       params: { classId: "class-1", slug: "lesson-1" },
@@ -66,8 +64,6 @@ describe("Class lesson completions route", () => {
       id: "lesson-1",
       title: "Earth systems",
     });
-
-    (prisma.classEnrollment.findFirst as vi.Mock).mockResolvedValue({ id: "enroll-1" });
 
     (prisma.classEnrollment.findMany as vi.Mock).mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
- hide completion entrypoints from students across dashboard and lesson page
- gate the class completion report page and API to teachers only
- cover the RBAC behavior with dashboard, page, and integration tests

Fixes #20.

## Testing
- npm run test -- 'app/(dashboard)/dashboard/page.test.tsx' 'app/(dashboard)/classes/[classId]/lessons/[slug]/completions/page.test.tsx' tests/integration/class-lesson-completions-route.test.ts
