### PR TITLE
feat: Task: BE - Create lesson content API endpoint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## In Progress
 
-- [ ] *(none currently)*
+- [ ] #75 - Task: BE - Create lesson content API endpoint (feat/75-task-be-create-lesson-content-api-endpoi) - Started: 2025-10-21
 
 ## In Review
 

--- a/app/api/lessons/[lessonSlug]/route.integration.test.ts
+++ b/app/api/lessons/[lessonSlug]/route.integration.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import prisma from '@/lib/prisma';
+import type { user as UserModel, Class, Lesson, Standard } from '@prisma/client';
+import { GET } from './route';
+import { createSession, setPrismaClient } from '@/lib/auth/session';
+
+const mockCookies = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => mockCookies),
+}));
+
+describe('GET /api/lessons/[lessonSlug] - Integration Tests', () => {
+  beforeAll(() => {
+    setPrismaClient(prisma);
+  });
+
+  let testTeacher: UserModel;
+  let testStudent: UserModel;
+  let otherStudent: UserModel;
+  let testClass: Class;
+  let testLesson: Lesson;
+  let testStandard: Standard;
+
+  beforeEach(async () => {
+    mockCookies.get.mockReset();
+    mockCookies.set.mockReset();
+    mockCookies.delete.mockReset();
+    mockCookies.get.mockReturnValue(undefined);
+
+    await prisma.$executeRaw`DELETE FROM "_CurriculumUnitToLesson"`;
+    await prisma.$executeRaw`DELETE FROM "_LessonToStandard"`;
+    await prisma.curriculumUnit.deleteMany();
+    await prisma.lesson.deleteMany();
+    await prisma.standard.deleteMany();
+    await prisma.class.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.account.deleteMany();
+    await prisma.user.deleteMany();
+
+    testTeacher = await prisma.user.create({
+      data: {
+        id: 'test-teacher-lesson-endpoint',
+        name: 'Test Teacher',
+        username: 'testteacher-lesson-endpoint',
+        displayUsername: 'TeacherLesson',
+        email: 'teacher-lesson@example.com',
+        role: 'TEACHER',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    testStudent = await prisma.user.create({
+      data: {
+        id: 'test-student-lesson-endpoint',
+        name: 'Test Student',
+        username: 'teststudent-lesson-endpoint',
+        displayUsername: 'StudentLesson',
+        email: 'student-lesson@example.com',
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    otherStudent = await prisma.user.create({
+      data: {
+        id: 'other-student-lesson-endpoint',
+        name: 'Other Student',
+        username: 'otherstudent-lesson-endpoint',
+        displayUsername: 'OtherLesson',
+        email: 'other-lesson@example.com',
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    testStandard = await prisma.standard.create({
+      data: {
+        id: 'standard-lesson-endpoint',
+        framework: 'THAI',
+        code: 'Sc1.1-G3',
+        description: 'Identify characteristics of living things',
+        gradeLevel: 3,
+      },
+    });
+
+    testLesson = await prisma.lesson.create({
+      data: {
+        id: 'lesson-endpoint',
+        title: 'Plants and Animals',
+        description: 'Compare characteristics of plants and animals',
+        content: 'Plants make their own food, animals consume food.',
+        gradeLevel: 3,
+        order: 1,
+        standards: {
+          connect: [{ id: testStandard.id }],
+        },
+      },
+      include: {
+        standards: true,
+      },
+    });
+
+    testClass = await prisma.class.create({
+      data: {
+        id: 'class-lesson-endpoint',
+        name: 'Grade 3 Science',
+        gradeLevel: 3,
+        standardsAlignment: 'THAI',
+        joinCode: 'LESSON',
+        teacherId: testTeacher.id,
+        students: {
+          connect: { id: testStudent.id },
+        },
+      },
+    });
+
+    await prisma.curriculumUnit.create({
+      data: {
+        id: 'unit-lesson-endpoint',
+        title: 'Living Things',
+        description: 'Introduction to living organisms',
+        framework: 'THAI',
+        gradeLevel: 3,
+        order: 1,
+        classId: testClass.id,
+        lessons: {
+          connect: [{ id: testLesson.id }],
+        },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.$executeRaw`DELETE FROM "_CurriculumUnitToLesson"`;
+    await prisma.$executeRaw`DELETE FROM "_LessonToStandard"`;
+    await prisma.curriculumUnit.deleteMany();
+    await prisma.lesson.deleteMany();
+    await prisma.standard.deleteMany();
+    await prisma.class.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.account.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockCookies.get.mockReturnValue(undefined);
+
+    const request = new NextRequest('http://localhost:3000/api/lessons/lesson-endpoint');
+    const response = await GET(request, {
+      params: Promise.resolve({ lessonSlug: testLesson.id }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Authentication required');
+  });
+
+  it('returns 404 when lesson does not exist', async () => {
+    const session = await createSession(testStudent.id);
+    mockCookies.get.mockReturnValue({ value: session.id });
+
+    const request = new NextRequest('http://localhost:3000/api/lessons/missing-lesson');
+    const response = await GET(request, {
+      params: Promise.resolve({ lessonSlug: 'missing-lesson' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Lesson not found');
+  });
+
+  it('returns 403 when user is not connected to a class with the lesson', async () => {
+    const session = await createSession(otherStudent.id);
+    mockCookies.get.mockReturnValue({ value: session.id });
+
+    const request = new NextRequest('http://localhost:3000/api/lessons/lesson-endpoint');
+    const response = await GET(request, {
+      params: Promise.resolve({ lessonSlug: testLesson.id }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('Not enrolled in a class with this lesson');
+  });
+
+  it('allows an enrolled student to fetch lesson content', async () => {
+    const session = await createSession(testStudent.id);
+    mockCookies.get.mockReturnValue({ value: session.id });
+
+    const request = new NextRequest('http://localhost:3000/api/lessons/lesson-endpoint');
+    const response = await GET(request, {
+      params: Promise.resolve({ lessonSlug: testLesson.id }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.lesson.id).toBe(testLesson.id);
+    expect(data.lesson.slug).toBe(testLesson.id);
+    expect(data.lesson.title).toBe('Plants and Animals');
+    expect(Array.isArray(data.lesson.objectives)).toBe(true);
+    expect(data.lesson.objectives).toContain('Compare characteristics of plants and animals');
+    expect(Array.isArray(data.standards)).toBe(true);
+    expect(data.standards[0]).toMatchObject({
+      id: testStandard.id,
+      code: testStandard.code,
+      description: testStandard.description,
+      framework: testStandard.framework,
+      gradeLevel: testStandard.gradeLevel,
+    });
+  });
+
+  it('allows the class teacher to fetch lesson content', async () => {
+    const session = await createSession(testTeacher.id);
+    mockCookies.get.mockReturnValue({ value: session.id });
+
+    const request = new NextRequest('http://localhost:3000/api/lessons/lesson-endpoint');
+    const response = await GET(request, {
+      params: Promise.resolve({ lessonSlug: testLesson.id }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.lesson.id).toBe(testLesson.id);
+  });
+});

--- a/app/api/lessons/[lessonSlug]/route.ts
+++ b/app/api/lessons/[lessonSlug]/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCurrentSession } from '@/lib/auth/session';
+import prisma from '@/lib/prisma';
+
+type LessonRouteContext = {
+  params: Promise<{
+    lessonSlug: string;
+  }>;
+};
+
+/**
+ * GET /api/lessons/{lessonSlug}
+ * Returns lesson content with the standards it satisfies.
+ *
+ * Authentication: Required (must be teacher of, admin of, or enrolled in a class that uses the lesson)
+ */
+export async function GET(request: NextRequest, context: LessonRouteContext) {
+  try {
+    const session = await getCurrentSession();
+
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const { lessonSlug } = await context.params;
+
+    const lesson = await prisma.lesson.findUnique({
+      where: { id: lessonSlug },
+      include: {
+        standards: true,
+        curriculumUnits: {
+          include: {
+            class: {
+              include: {
+                teacher: {
+                  select: { id: true },
+                },
+                students: {
+                  select: { id: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!lesson) {
+      return NextResponse.json(
+        { error: 'Lesson not found' },
+        { status: 404 }
+      );
+    }
+
+    const userId = session.user.id;
+    const userRole = session.user.role;
+
+    const hasAccess = lesson.curriculumUnits.some(unit => {
+      const classRecord = unit.class;
+      if (!classRecord) {
+        return false;
+      }
+
+      if (classRecord.teacher.id === userId) {
+        return true;
+      }
+
+      if (classRecord.students.some(student => student.id === userId)) {
+        return true;
+      }
+
+      return userRole === 'ADMIN' || userRole === 'SYSTEM';
+    });
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'Not enrolled in a class with this lesson' },
+        { status: 403 }
+      );
+    }
+
+    const responsePayload = {
+      lesson: {
+        id: lesson.id,
+        slug: lesson.id, // TODO: Replace with dedicated slug when available
+        title: lesson.title,
+        titleThai: lesson.title, // TODO: Surface localized title when schema supports it
+        content: lesson.content ?? '',
+        contentThai: lesson.content ?? '', // TODO: Surface localized content when available
+        objectives: lesson.description ? [lesson.description] : [],
+        objectivesThai: lesson.description ? [lesson.description] : [],
+      },
+      standards: lesson.standards.map(standard => ({
+        id: standard.id,
+        code: standard.code,
+        description: standard.description,
+        descriptionThai: standard.description, // TODO: Provide Thai translation when available
+        framework: standard.framework,
+        gradeLevel: standard.gradeLevel,
+      })),
+    };
+
+    return NextResponse.json(responsePayload, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch lesson:', error);
+
+    return NextResponse.json(
+      { error: 'An unexpected error occurred while fetching the lesson' },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/sprint/S2-Student-Experience.md
+++ b/docs/sprint/S2-Student-Experience.md
@@ -92,7 +92,7 @@
   - A section on the page clearly lists the specific `Standard(s)` that the lesson fulfills (e.g., "Covers Standard: NGSS 3-LS1-1"). This data is pulled from the lesson's relationship with the `Standard` model.
 
 **Tasks:**
-- #75: Task: BE - Create lesson content API endpoint
+- #75: Task: BE - Create lesson content API endpoint (Status: In Progress, Branch: feat/75-task-be-create-lesson-content-api-endpoi, Started: 2025-10-21)
 - #76: Task: FE - Display lesson content
 
 ### Story: Student Settings Page


### PR DESCRIPTION
This task is part of story #66. 

**Acceptance Criteria:**

* Create an API endpoint `GET /api/lessons/{lessonSlug}`.
* The endpoint should return the main content of the lesson and a list of the specific `Standard(s)` that the lesson fulfills.

**API Contract:**

```typescript
// GET /api/lessons/{lessonSlug}
// Authentication: Required (student must be enrolled in a class using this lesson)

Request: lessonSlug in URL path

Success Response (200):
{
  "lesson": {
    "id": string,
    "slug": string,
    "title": string,
    "titleThai": string,
    "content": string,        // Main lesson content
    "contentThai": string,
    "objectives": string[],
    "objectivesThai": string[]
  },
  "standards": [
    {
      "id": string,
      "code": string,          // e.g., "Sc1.1/3"
      "description": string,
      "descriptionThai": string,
      "framework": "THAI" | "NGSS",
      "gradeLevel": number
    }
  ]
}

Error Responses:
401 - { "error": "Authentication required" }
403 - { "error": "Not enrolled in a class with this lesson" }
404 - { "error": "Lesson not found" }
```

**Security:**
- Verify user is enrolled in at least one class that includes this lesson
- Support both Thai and NGSS standards mappings

Closes #75