### PR TITLE
feat: Task: FE - Display lesson content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## In Progress
 
-- [ ] #75 - Task: BE - Create lesson content API endpoint (feat/75-task-be-create-lesson-content-api-endpoi) - Started: 2025-10-21
+- [ ] #76 - Task: FE - Display lesson content (feat/76-task-fe-display-lesson-content) - Started: 2025-10-21
 
 ## In Review
 

--- a/app/(student)/student/classes/[classId]/lessons/[lessonSlug]/page.tsx
+++ b/app/(student)/student/classes/[classId]/lessons/[lessonSlug]/page.tsx
@@ -1,0 +1,18 @@
+import { LessonViewer } from '@/components/features/student/lesson-viewer';
+
+interface PageProps {
+  params: Promise<{
+    classId: string;
+    lessonSlug: string;
+  }>;
+}
+
+export default async function LessonPage({ params }: PageProps) {
+  const { classId, lessonSlug } = await params;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <LessonViewer classId={classId} lessonSlug={lessonSlug} />
+    </div>
+  );
+}

--- a/components/features/student/lesson-viewer.tsx
+++ b/components/features/student/lesson-viewer.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface Standard {
+  id: string;
+  code: string;
+  description: string;
+  descriptionThai: string;
+  framework: 'THAI' | 'NGSS';
+  gradeLevel: number;
+}
+
+interface LessonData {
+  lesson: {
+    id: string;
+    slug: string;
+    title: string;
+    titleThai: string;
+    content: string;
+    contentThai: string;
+    objectives: string[];
+    objectivesThai: string[];
+  };
+  standards: Standard[];
+}
+
+interface LessonViewerProps {
+  classId: string;
+  lessonSlug: string;
+}
+
+export function LessonViewer({ classId, lessonSlug }: LessonViewerProps) {
+  const router = useRouter();
+  const [lessonData, setLessonData] = useState<LessonData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchLesson() {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await fetch(`/api/lessons/${lessonSlug}`);
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new Error('Please sign in to view this lesson');
+          } else if (response.status === 403) {
+            throw new Error('You are not enrolled in a class with this lesson');
+          } else if (response.status === 404) {
+            throw new Error('Lesson not found');
+          } else {
+            throw new Error('Failed to load lesson');
+          }
+        }
+
+        const data = await response.json();
+        setLessonData(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchLesson();
+  }, [lessonSlug]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-rose-600" />
+        <span className="ml-2 text-gray-600">Loading lesson...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <Button
+          variant="ghost"
+          onClick={() => router.back()}
+          className="gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to curriculum
+        </Button>
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+          <p className="text-sm font-medium text-red-800">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!lessonData) {
+    return (
+      <div className="space-y-4">
+        <Button
+          variant="ghost"
+          onClick={() => router.back()}
+          className="gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to curriculum
+        </Button>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6 text-center">
+          <p className="text-sm text-gray-600">No lesson data available.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Button
+        variant="ghost"
+        onClick={() => router.push(`/student/classes/${classId}`)}
+        className="gap-2"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to curriculum
+      </Button>
+
+      {/* Lesson Header */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-gray-900">{lessonData.lesson.title}</h1>
+        {lessonData.lesson.titleThai !== lessonData.lesson.title && (
+          <p className="text-xl text-gray-600">{lessonData.lesson.titleThai}</p>
+        )}
+      </div>
+
+      {/* Learning Objectives */}
+      {lessonData.lesson.objectives.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Learning Objectives</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-disc space-y-2 pl-5">
+              {lessonData.lesson.objectives.map((objective, index) => (
+                <li key={index} className="text-gray-700">
+                  {objective}
+                </li>
+              ))}
+            </ul>
+            {lessonData.lesson.objectivesThai.some(
+              (thai, i) => thai !== lessonData.lesson.objectives[i]
+            ) && (
+              <div className="mt-4 border-t pt-4">
+                <p className="mb-2 text-sm font-semibold text-gray-600">วัตถุประสงค์การเรียนรู้:</p>
+                <ul className="list-disc space-y-2 pl-5">
+                  {lessonData.lesson.objectivesThai.map((objective, index) => (
+                    <li key={index} className="text-gray-700">
+                      {objective}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Lesson Content */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Lesson Content</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="prose prose-sm max-w-none">
+            <div className="whitespace-pre-wrap text-gray-700">
+              {lessonData.lesson.content || 'No content available for this lesson.'}
+            </div>
+            {lessonData.lesson.contentThai !== lessonData.lesson.content && (
+              <div className="mt-6 border-t pt-6">
+                <p className="mb-3 text-sm font-semibold text-gray-600">เนื้อหาบทเรียน:</p>
+                <div className="whitespace-pre-wrap text-gray-700">
+                  {lessonData.lesson.contentThai}
+                </div>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Standards Covered */}
+      {lessonData.standards.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Standards Covered</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {lessonData.standards.map((standard) => (
+                <div
+                  key={standard.id}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <Badge
+                      variant="outline"
+                      className={
+                        standard.framework === 'THAI'
+                          ? 'bg-blue-50 text-blue-700 border-blue-200'
+                          : 'bg-purple-50 text-purple-700 border-purple-200'
+                      }
+                    >
+                      {standard.framework}
+                    </Badge>
+                    <div className="flex-1">
+                      <p className="font-semibold text-gray-900">
+                        {standard.code}
+                      </p>
+                      <p className="mt-1 text-sm text-gray-700">
+                        {standard.description}
+                      </p>
+                      {standard.descriptionThai !== standard.description && (
+                        <p className="mt-2 text-sm text-gray-600">
+                          {standard.descriptionThai}
+                        </p>
+                      )}
+                      <p className="mt-2 text-xs text-gray-500">
+                        Grade {standard.gradeLevel}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/components/features/student/student-curriculum-view.tsx
+++ b/components/features/student/student-curriculum-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Loader2, CheckCircle2, Circle } from 'lucide-react';
@@ -38,6 +39,7 @@ interface StudentCurriculumViewProps {
 }
 
 export function StudentCurriculumView({ classId }: StudentCurriculumViewProps) {
+  const router = useRouter();
   const [curriculum, setCurriculum] = useState<CurriculumData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -132,6 +134,7 @@ export function StudentCurriculumView({ classId }: StudentCurriculumViewProps) {
                   {unit.lessons.map(lesson => (
                     <li
                       key={lesson.id}
+                      onClick={() => router.push(`/student/classes/${classId}/lessons/${lesson.slug}`)}
                       className="rounded-lg border border-gray-100 bg-white p-4 shadow-sm transition hover:border-rose-200 hover:shadow-md cursor-pointer"
                     >
                       <div className="flex items-start justify-between gap-3">

--- a/docs/sprint/S2-Student-Experience.md
+++ b/docs/sprint/S2-Student-Experience.md
@@ -92,8 +92,8 @@
   - A section on the page clearly lists the specific `Standard(s)` that the lesson fulfills (e.g., "Covers Standard: NGSS 3-LS1-1"). This data is pulled from the lesson's relationship with the `Standard` model.
 
 **Tasks:**
-- #75: Task: BE - Create lesson content API endpoint (Status: In Progress, Branch: feat/75-task-be-create-lesson-content-api-endpoi, Started: 2025-10-21)
-- #76: Task: FE - Display lesson content
+- #75: Task: BE - Create lesson content API endpoint (Status: Completed ✅, Branch: feat/75-task-be-create-lesson-content-api-endpoi, Started: 2025-10-21, Completed: 2025-10-21)
+- #76: Task: FE - Display lesson content (Status: In Progress, Branch: feat/76-task-fe-display-lesson-content, Started: 2025-10-21)
 
 ### Story: Student Settings Page
 


### PR DESCRIPTION
## Summary

Implements the frontend for Story #66 (Task #76), allowing students to view individual lesson content with learning objectives and standards coverage.

## Changes

**New Page Route:**
- ✅ Created `/student/classes/[classId]/lessons/[lessonSlug]` route
- ✅ Renders LessonViewer component for displaying lesson content

**New Component:**
- ✅ `LessonViewer`: Client component that fetches lesson from `/api/lessons/{lessonSlug}` and renders content
- ✅ Displays lesson title (bilingual: English/Thai)
- ✅ Shows learning objectives section
- ✅ Renders main lesson content with proper formatting
- ✅ Lists all standards covered with framework badges (THAI/NGSS)

**Updated Component:**
- ✅ `StudentCurriculumView`: Added click navigation to lessons
- ✅ Lessons now navigate to viewer when clicked

**Features:**
- Loading state with spinner
- Error handling for 401 (auth), 403 (not enrolled), 404 (not found), 500 (server error)
- Back button navigation to curriculum view
- Bilingual content support (Thai/English)
- Responsive card-based layout
- Framework badges for standards (THAI in blue, NGSS in purple)
- Grade level display for each standard

## API Integration

Consumes the endpoint from #75:
```typescript
GET /api/lessons/{lessonSlug}
Response: {
  lesson: { id, slug, title, titleThai, content, contentThai, objectives, objectivesThai },
  standards: [{ id, code, description, descriptionThai, framework, gradeLevel }]
}
```

## Acceptance Criteria

- [x] Create a lesson viewer page that fetches lesson content from the API ✅
- [x] Display the main lesson content ✅
- [x] Display a section listing the Standards that the lesson fulfills ✅
- [x] Display bilingual content (Thai/English) ✅
- [x] Show all mapped standards with codes and descriptions ✅
- [x] Handle both THAI and NGSS framework standards ✅
- [x] Format lesson content properly ✅

## Testing

**Build & Lint:**
- ✅ `npm run lint` - No errors or warnings
- ✅ `npm run build` - Successful compilation
- ✅ TypeScript validation passed

**Manual Testing:**
_(Recommended to verify UI/UX)_
1. Sign in as demo_student
2. Navigate to enrolled class
3. Click on any lesson in curriculum
4. Verify lesson content displays with objectives and standards
5. Test back navigation
6. Test error states (try invalid lesson slug)

## Dependencies

- ✅ Depends on #75 (backend API) - **MERGED** ✅
- Part of Story #66 - View Lesson Content and Standards

## Notes

**Current Limitations:**
- Thai translations show same as English in some places (schema doesn't support full localization yet)
- Content is displayed as plain text (markdown rendering can be added in future enhancement)

**Design Decisions:**
- Card-based layout for clear visual separation of sections
- Framework badges use distinct colors for easy identification
- Back button provides clear navigation path
- Client-side fetching for better user experience (loading states, error handling)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>