### PR TITLE
feat: Story #95 - Lesson Progress Tracking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,13 @@
 - [ ] #93 - Story: Quiz Taking API (P1) - Created: 2025-10-22
 - [ ] #94 - Story: Quiz UI Components (P1) - Created: 2025-10-22
 - [ ] #95 - Story: Lesson Progress Tracking (P1) - Created: 2025-10-22
+  - **Status**: In Progress
+  - **Started**: 2025-10-25
+  - **Branch**: feat/95-lesson-progress-tracking
+  - **Specs**: docs/specs/progress-tracking/spec.md
+  - **Priority**: P1
+  - **Milestone**: Sprint 3: Interactive Learning
+  - **Dependencies**: None
 - [ ] #96 - Story: Teacher Analytics - Class Overview (P1) - Created: 2025-10-22
 - [ ] #97 - Story: Teacher Analytics - Lesson Detail (P1) - Created: 2025-10-22
 - [ ] #98 - Story: Teacher Analytics - Student-Lesson Detail (P1) - Created: 2025-10-22

--- a/app/(student)/student/classes/[classId]/lessons/[lessonSlug]/page.tsx
+++ b/app/(student)/student/classes/[classId]/lessons/[lessonSlug]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, use } from 'react';
+import { useState, useEffect, useCallback, use } from 'react';
 import { LessonViewer } from '@/components/features/student/lesson-viewer';
 import { QuizPlayer } from '@/components/features/student/quiz-player';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,48 @@ interface PageProps {
 
 export default function LessonPage({ params }: PageProps) {
   const [view, setView] = useState<'lesson' | 'quiz'>('lesson');
+  const [progress, setProgress] = useState<LessonProgressResponse | null>(null);
+  const [progressLoading, setProgressLoading] = useState(true);
   const { classId, lessonSlug } = use(params);
+
+  const fetchProgress = useCallback(async () => {
+    try {
+      setProgressLoading(true);
+      const response = await fetch(`/api/students/me/lessons/${lessonSlug}/progress`);
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          setProgress(null);
+          return;
+        }
+        if (response.status === 401) {
+          throw new Error('Please sign in to view progress');
+        }
+        throw new Error('Failed to load lesson progress');
+      }
+
+      const data = (await response.json()) as LessonProgressResponse;
+      setProgress(data);
+    } catch (error) {
+      console.error(error);
+      setProgress(null);
+    } finally {
+      setProgressLoading(false);
+    }
+  }, [lessonSlug]);
+
+  useEffect(() => {
+    fetchProgress();
+  }, [fetchProgress]);
+
+  const handleStartQuiz = useCallback(() => {
+    setView('quiz');
+  }, []);
+
+  const handleQuizCompleted = useCallback(() => {
+    setView('lesson');
+    fetchProgress();
+  }, [fetchProgress]);
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
@@ -41,10 +82,28 @@ export default function LessonPage({ params }: PageProps) {
 
       {/* Content */}
       {view === 'lesson' ? (
-        <LessonViewer classId={classId} lessonSlug={lessonSlug} />
+        <LessonViewer
+          classId={classId}
+          lessonSlug={lessonSlug}
+          progress={progress}
+          progressLoading={progressLoading}
+          onStartQuiz={handleStartQuiz}
+        />
       ) : (
-        <QuizPlayer classId={classId} lessonSlug={lessonSlug} />
+        <QuizPlayer classId={classId} lessonSlug={lessonSlug} onQuizCompleted={handleQuizCompleted} />
       )}
     </div>
   );
+}
+
+interface LessonProgressResponse {
+  status: 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+  attemptsCount: number;
+  mostRecentScore: number | null;
+  mostRecentScorePercentage: number | null;
+  bestScore: number | null;
+  bestScorePercentage: number | null;
+  completedAt: string | null;
+  lastAttemptAt: string | null;
+  totalTimeSpentSeconds: number;
 }

--- a/app/api/classes/[classId]/curriculum/route.integration.test.ts
+++ b/app/api/classes/[classId]/curriculum/route.integration.test.ts
@@ -37,6 +37,9 @@ describe('GET /api/classes/[classId]/curriculum - Integration Tests', () => {
     mockCookies.get.mockReturnValue(undefined);
 
     // Clean up in correct order
+    await prisma.questionResponse.deleteMany();
+    await prisma.attempt.deleteMany();
+    await prisma.lessonCompletion.deleteMany();
     await prisma.$executeRaw`DELETE FROM "_CurriculumUnitToLesson"`;
     await prisma.$executeRaw`DELETE FROM "_LessonToStandard"`;
     await prisma.curriculumUnit.deleteMany();
@@ -168,6 +171,9 @@ describe('GET /api/classes/[classId]/curriculum - Integration Tests', () => {
   });
 
   afterEach(async () => {
+    await prisma.questionResponse.deleteMany();
+    await prisma.attempt.deleteMany();
+    await prisma.lessonCompletion.deleteMany();
     await prisma.$executeRaw`DELETE FROM "_CurriculumUnitToLesson"`;
     await prisma.$executeRaw`DELETE FROM "_LessonToStandard"`;
     await prisma.curriculumUnit.deleteMany();
@@ -344,6 +350,15 @@ describe('GET /api/classes/[classId]/curriculum - Integration Tests', () => {
       expect(lesson).toHaveProperty('order');
       expect(lesson).toHaveProperty('completed');
       expect(lesson).toHaveProperty('started');
+      expect(lesson).toHaveProperty('progress');
+      expect(lesson.progress).toMatchObject({
+        status: 'NOT_STARTED',
+        attemptsCount: 0,
+        mostRecentScore: null,
+        mostRecentScorePercentage: null,
+        bestScore: null,
+        bestScorePercentage: null,
+      });
     });
 
     it('should set placeholder progress values', async () => {

--- a/app/api/classes/[classId]/curriculum/route.ts
+++ b/app/api/classes/[classId]/curriculum/route.ts
@@ -81,7 +81,23 @@ export async function GET(
       },
     });
 
-    // 6. Format response according to API contract
+    // 6. Gather lesson completions for current student (if applicable)
+    const lessonIds = units.flatMap(unit => unit.lessons.map(lesson => lesson.id));
+    const completions =
+      lessonIds.length === 0
+        ? []
+        : await prisma.lessonCompletion.findMany({
+          where: {
+            studentId: session.user.id,
+            lessonId: { in: lessonIds },
+          },
+        });
+
+    const lessonsProgressMap = new Map(
+      completions.map(completion => [completion.lessonId, completion])
+    );
+
+    // 7. Format response according to API contract
     const response = {
       class: {
         id: classRecord.id,
@@ -94,15 +110,35 @@ export async function GET(
         title: unit.title,
         titleThai: unit.title, // TODO: Add Thai translations when schema supports it
         order: unit.order,
-        lessons: unit.lessons.map(lesson => ({
-          id: lesson.id,
-          slug: lesson.id, // TODO: Use slug field when schema supports it
-          title: lesson.title,
-          titleThai: lesson.title, // TODO: Add Thai translations when schema supports it
-          order: lesson.order,
-          completed: false, // Placeholder - will be implemented with progress tracking
-          started: false,   // Placeholder - will be implemented with progress tracking
-        })),
+        lessons: unit.lessons.map(lesson => {
+          const progress = lessonsProgressMap.get(lesson.id);
+          const status = progress?.status ?? 'NOT_STARTED';
+          const mostRecentScorePercentage = progress?.mostRecentScorePercentage ?? null;
+          const mostRecentScore = progress?.mostRecentScore ?? null;
+          const bestScorePercentage = progress?.bestScorePercentage ?? null;
+          const bestScore = progress?.bestScore ?? null;
+          const attemptsCount = progress?.attemptsCount ?? 0;
+
+          return {
+            id: lesson.id,
+            slug: lesson.id, // TODO: Use slug field when schema supports it
+            title: lesson.title,
+            titleThai: lesson.title, // TODO: Add Thai translations when schema supports it
+            order: lesson.order,
+            completed: status === 'COMPLETED',
+            started: status !== 'NOT_STARTED',
+            progress: {
+              status,
+              attemptsCount,
+              mostRecentScore,
+              mostRecentScorePercentage,
+              bestScore,
+              bestScorePercentage,
+              lastAttemptAt: progress?.lastAttemptAt?.toISOString() ?? null,
+              completedAt: progress?.completedAt?.toISOString() ?? null,
+            },
+          };
+        }),
       })),
     };
 

--- a/app/api/lessons/[lessonSlug]/quiz/route.ts
+++ b/app/api/lessons/[lessonSlug]/quiz/route.ts
@@ -120,7 +120,42 @@ export async function GET(
       },
     });
 
-    // 10. Format response (exclude correctAnswer)
+    // 10. Ensure a lesson completion record exists so curriculum can show "Started"
+    const existingCompletion = await prisma.lessonCompletion.findUnique({
+      where: {
+        studentId_lessonId: {
+          studentId: session.user.id,
+          lessonId: lessonSlug,
+        },
+      },
+    });
+
+    if (!existingCompletion) {
+      await prisma.lessonCompletion.create({
+        data: {
+          studentId: session.user.id,
+          lessonId: lessonSlug,
+          status: 'IN_PROGRESS',
+          attemptsCount: 0,
+          lastAttemptAt: new Date(),
+        },
+      });
+    } else if (existingCompletion.status === 'NOT_STARTED') {
+      await prisma.lessonCompletion.update({
+        where: {
+          studentId_lessonId: {
+            studentId: session.user.id,
+            lessonId: lessonSlug,
+          },
+        },
+        data: {
+          status: 'IN_PROGRESS',
+          lastAttemptAt: new Date(),
+        },
+      });
+    }
+
+    // 11. Format response (exclude correctAnswer)
     const response = {
       quizId: attempt.id,
       lessonId: lessonSlug,
@@ -278,6 +313,14 @@ export async function POST(
       });
     }
 
+    const percentage = (totalScore / attempt.maxScore) * 100;
+
+    // Calculate total time spent on this attempt
+    const attemptTimeSpent = questionResponsesToCreate.reduce(
+      (sum, qr) => sum + qr.timeSpentSeconds,
+      0
+    );
+
     // 8. Use transaction to ensure data consistency
     await prisma.$transaction(async tx => {
       // Update attempt with score and completion time
@@ -295,8 +338,6 @@ export async function POST(
       });
 
       // Update or create LessonCompletion record
-      const percentage = (totalScore / attempt.maxScore) * 100;
-
       const existingCompletion = await tx.lessonCompletion.findUnique({
         where: {
           studentId_lessonId: {
@@ -328,8 +369,9 @@ export async function POST(
                 ? Math.max(existingCompletion.bestScorePercentage, percentage)
                 : percentage,
             lastAttemptAt: new Date(),
-            status: percentage >= 60 ? 'COMPLETED' : 'IN_PROGRESS',
-            completedAt: percentage >= 60 ? new Date() : existingCompletion.completedAt,
+            status: 'COMPLETED',
+            completedAt: new Date(),
+            totalTimeSpentSeconds: existingCompletion.totalTimeSpentSeconds + attemptTimeSpent,
           },
         });
       } else {
@@ -338,22 +380,21 @@ export async function POST(
           data: {
             studentId: session.user.id,
             lessonId: lessonSlug,
-            status: percentage >= 60 ? 'COMPLETED' : 'IN_PROGRESS',
+            status: 'COMPLETED',
             attemptsCount: 1,
             bestScore: totalScore,
             bestScorePercentage: percentage,
             mostRecentScore: totalScore,
             mostRecentScorePercentage: percentage,
             lastAttemptAt: new Date(),
-            completedAt: percentage >= 60 ? new Date() : null,
+            completedAt: new Date(),
+            totalTimeSpentSeconds: attemptTimeSpent,
           },
         });
       }
     });
 
     // 9. Format and return response
-    const percentage = (totalScore / attempt.maxScore) * 100;
-
     return NextResponse.json(
       {
         attemptId,

--- a/app/api/students/[studentId]/lessons/[lessonId]/progress/route.ts
+++ b/app/api/students/[studentId]/lessons/[lessonId]/progress/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCurrentSession } from '@/lib/auth/session';
+import prisma from '@/lib/prisma';
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ studentId: string; lessonId: string }> }
+) {
+  try {
+    const session = await getCurrentSession();
+
+    if (!session) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const { studentId: requestedStudentId, lessonId } = await context.params;
+    const targetStudentId = requestedStudentId === 'me' ? session.user.id : requestedStudentId;
+
+    const student = await prisma.user.findUnique({
+      where: { id: targetStudentId },
+      select: { id: true },
+    });
+
+    if (!student) {
+      return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+    }
+
+    const lesson = await prisma.lesson.findUnique({
+      where: { id: lessonId },
+      include: {
+        curriculumUnits: {
+          include: {
+            class: {
+              include: {
+                teacher: { select: { id: true } },
+                students: { select: { id: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!lesson) {
+      return NextResponse.json({ error: 'Lesson not found' }, { status: 404 });
+    }
+
+    const isSelf = targetStudentId === session.user.id;
+
+    const authorizedViaClass = lesson.curriculumUnits.some(unit => {
+      const isTeacher = unit.class.teacher.id === session.user.id;
+      const studentInClass = unit.class.students.some(s => s.id === targetStudentId);
+      return isTeacher && studentInClass;
+    });
+
+    if (!isSelf && !authorizedViaClass) {
+      return NextResponse.json({ error: 'Not authorized to view progress' }, { status: 403 });
+    }
+
+    const completion = await prisma.lessonCompletion.findUnique({
+      where: {
+        studentId_lessonId: {
+          studentId: targetStudentId,
+          lessonId,
+        },
+      },
+    });
+
+    const response = {
+      studentId: targetStudentId,
+      lessonId,
+      status: completion?.status ?? 'NOT_STARTED',
+      attemptsCount: completion?.attemptsCount ?? 0,
+      bestScore: completion?.bestScore ?? null,
+      bestScorePercentage: completion?.bestScorePercentage ?? null,
+      mostRecentScore: completion?.mostRecentScore ?? null,
+      mostRecentScorePercentage: completion?.mostRecentScorePercentage ?? null,
+      totalTimeSpentSeconds: completion?.totalTimeSpentSeconds ?? 0,
+      lastAttemptAt: completion?.lastAttemptAt?.toISOString() ?? null,
+      completedAt: completion?.completedAt?.toISOString() ?? null,
+    };
+
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch lesson progress:', error);
+    return NextResponse.json(
+      { error: 'An unexpected error occurred while fetching progress' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/features/student/lesson-viewer.tsx
+++ b/components/features/student/lesson-viewer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Loader2 } from 'lucide-react';
+import { ArrowLeft, Loader2, FileQuestion } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -30,16 +30,81 @@ interface LessonData {
   standards: Standard[];
 }
 
+type LessonProgressStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+
+interface LessonProgressSummary {
+  status: LessonProgressStatus;
+  attemptsCount: number;
+  mostRecentScore: number | null;
+  mostRecentScorePercentage: number | null;
+  bestScore: number | null;
+  bestScorePercentage: number | null;
+}
+
 interface LessonViewerProps {
   classId: string;
   lessonSlug: string;
+  progress?: LessonProgressSummary | null;
+  progressLoading?: boolean;
+  onStartQuiz?: () => void;
 }
 
-export function LessonViewer({ classId, lessonSlug }: LessonViewerProps) {
+const PROGRESS_STATUS_META: Record<
+  LessonProgressStatus,
+  { label: string; badgeClass: string; description: string }
+> = {
+  NOT_STARTED: {
+    label: 'Not Started',
+    badgeClass: 'bg-gray-50 text-gray-600 border-gray-200',
+    description: 'Complete the lesson and start the quiz to track your progress.',
+  },
+  IN_PROGRESS: {
+    label: 'In Progress',
+    badgeClass: 'bg-amber-50 text-amber-700 border-amber-200',
+    description: 'You have started working on this lesson. Finish the quiz to see your score.',
+  },
+  COMPLETED: {
+    label: 'Completed',
+    badgeClass: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    description: 'Great work! Retake the quiz anytime to improve your score.',
+  },
+};
+
+const getScoreBadgeClass = (percentage: number) => {
+  if (percentage >= 90) return 'bg-blue-100 text-blue-900 border-blue-200';
+  if (percentage >= 80) return 'bg-emerald-100 text-emerald-900 border-emerald-200';
+  if (percentage >= 60) return 'bg-yellow-100 text-yellow-900 border-yellow-200';
+  return 'bg-rose-100 text-rose-900 border-rose-200';
+};
+
+const formatPercentage = (value: number | null) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return `${Math.round(value)}%`;
+};
+
+export function LessonViewer({ classId, lessonSlug, progress, progressLoading = false, onStartQuiz }: LessonViewerProps) {
   const router = useRouter();
   const [lessonData, setLessonData] = useState<LessonData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const progressSummary = useMemo<LessonProgressSummary>(() => {
+    return (
+      progress ?? {
+        status: 'NOT_STARTED',
+        attemptsCount: 0,
+        mostRecentScore: null,
+        mostRecentScorePercentage: null,
+        bestScore: null,
+        bestScorePercentage: null,
+      }
+    );
+  }, [progress]);
+
+  const statusMeta = PROGRESS_STATUS_META[progressSummary.status];
+  const hasScore = typeof progressSummary.mostRecentScorePercentage === 'number';
+  const ctaLabel = progressSummary.attemptsCount > 0 ? 'Retake Quiz' : 'Start Quiz';
 
   useEffect(() => {
     async function fetchLesson() {
@@ -118,6 +183,12 @@ export function LessonViewer({ classId, lessonSlug }: LessonViewerProps) {
     );
   }
 
+  const handleQuizCta = () => {
+    if (onStartQuiz) {
+      onStartQuiz();
+    }
+  };
+
   return (
     <div className="space-y-6">
       <Button
@@ -187,6 +258,75 @@ export function LessonViewer({ classId, lessonSlug }: LessonViewerProps) {
                 </div>
               </div>
             )}
+          </div>
+      </CardContent>
+      </Card>
+
+      {/* Lesson Progress & Quiz CTA */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Lesson Progress</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <Badge variant="outline" className={statusMeta.badgeClass}>
+                {statusMeta.label}
+              </Badge>
+              <p className="mt-2 text-sm text-gray-600">{statusMeta.description}</p>
+              <div className="mt-3 flex flex-wrap gap-4 text-sm text-gray-700">
+                <span>
+                  Attempts:{' '}
+                  <span className="font-semibold text-gray-900">
+                    {progressSummary.attemptsCount}
+                  </span>
+                </span>
+                {hasScore && (
+                  <>
+                    <span>
+                      Most recent:{' '}
+                      <span className="font-semibold text-gray-900">
+                        {formatPercentage(progressSummary.mostRecentScorePercentage)}
+                      </span>
+                    </span>
+                    <span>
+                      Best:{' '}
+                      <span className="font-semibold text-gray-900">
+                        {formatPercentage(progressSummary.bestScorePercentage ?? progressSummary.mostRecentScorePercentage)}
+                      </span>
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              {hasScore && progressSummary.mostRecentScorePercentage !== null && (
+                <span
+                  className={`rounded-full border px-3 py-1 text-sm font-semibold ${getScoreBadgeClass(
+                    progressSummary.mostRecentScorePercentage
+                  )}`}
+                >
+                  {formatPercentage(progressSummary.mostRecentScorePercentage)}
+                </span>
+              )}
+              <Button
+                onClick={handleQuizCta}
+                disabled={!onStartQuiz || progressLoading}
+                className="gap-2"
+              >
+                {progressLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Checking...
+                  </>
+                ) : (
+                  <>
+                    <FileQuestion className="h-4 w-4" />
+                    {ctaLabel}
+                  </>
+                )}
+              </Button>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/components/features/student/quiz-player.tsx
+++ b/components/features/student/quiz-player.tsx
@@ -69,9 +69,10 @@ interface QuizResult {
 interface QuizPlayerProps {
   classId: string;
   lessonSlug: string;
+  onQuizCompleted?: (result: QuizResult) => void;
 }
 
-export function QuizPlayer({ classId, lessonSlug }: QuizPlayerProps) {
+export function QuizPlayer({ classId, lessonSlug, onQuizCompleted }: QuizPlayerProps) {
   const router = useRouter();
 
   // Quiz state
@@ -231,13 +232,14 @@ export function QuizPlayer({ classId, lessonSlug }: QuizPlayerProps) {
       const resultData: QuizResult = await response.json();
       setResult(resultData);
       setShowSubmitDialog(false);
+      onQuizCompleted?.(resultData);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred');
       setShowSubmitDialog(false);
     } finally {
       setSubmitting(false);
     }
-  }, [quizData, answers, questionTimes, currentQuestionIndex, lessonSlug, allQuestionsAnswered, recordQuestionTime]);
+  }, [quizData, answers, questionTimes, currentQuestionIndex, lessonSlug, allQuestionsAnswered, recordQuestionTime, onQuizCompleted]);
 
   // Render loading state
   if (loading) {

--- a/components/features/student/student-curriculum-view.tsx
+++ b/components/features/student/student-curriculum-view.tsx
@@ -4,7 +4,21 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Loader2, CheckCircle2, Circle } from 'lucide-react';
+
+type LessonProgressStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+
+interface LessonProgress {
+  status: LessonProgressStatus;
+  attemptsCount: number;
+  mostRecentScore: number | null;
+  mostRecentScorePercentage: number | null;
+  bestScore: number | null;
+  bestScorePercentage: number | null;
+  lastAttemptAt: string | null;
+  completedAt: string | null;
+}
 
 interface Lesson {
   id: string;
@@ -14,6 +28,7 @@ interface Lesson {
   order: number;
   completed: boolean;
   started: boolean;
+  progress: LessonProgress;
 }
 
 interface CurriculumUnit {
@@ -37,6 +52,49 @@ interface CurriculumData {
 interface StudentCurriculumViewProps {
   classId: string;
 }
+
+const STATUS_CONFIG: Record<
+  LessonProgressStatus,
+  {
+    label: string;
+    icon: typeof Circle;
+    iconClass: string;
+    badgeClass: string;
+  }
+> = {
+  NOT_STARTED: {
+    label: 'Not Started',
+    icon: Circle,
+    iconClass: 'text-gray-300',
+    badgeClass: 'bg-gray-50 text-gray-600 border-gray-200',
+  },
+  IN_PROGRESS: {
+    label: 'In Progress',
+    icon: Circle,
+    iconClass: 'text-amber-500',
+    badgeClass: 'bg-amber-50 text-amber-700 border-amber-200',
+  },
+  COMPLETED: {
+    label: 'Completed',
+    icon: CheckCircle2,
+    iconClass: 'text-emerald-600',
+    badgeClass: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  },
+};
+
+const getScoreBadgeClass = (percentage: number) => {
+  if (percentage >= 90) return 'bg-blue-100 text-blue-900 border-blue-200';
+  if (percentage >= 80) return 'bg-emerald-100 text-emerald-900 border-emerald-200';
+  if (percentage >= 60) return 'bg-yellow-100 text-yellow-900 border-yellow-200';
+  return 'bg-rose-100 text-rose-900 border-rose-200';
+};
+
+const formatPercentage = (value: number | null) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return `${Math.round(value)}%`;
+};
 
 export function StudentCurriculumView({ classId }: StudentCurriculumViewProps) {
   const router = useRouter();
@@ -114,9 +172,10 @@ export function StudentCurriculumView({ classId }: StudentCurriculumViewProps) {
         </div>
       </div>
 
-      <Accordion type="multiple" className="divide-y divide-gray-200">
-        {curriculum.units.map(unit => (
-          <AccordionItem key={unit.id} value={unit.id} className="px-2">
+      <TooltipProvider delayDuration={200}>
+        <Accordion type="multiple" className="divide-y divide-gray-200">
+          {curriculum.units.map(unit => (
+            <AccordionItem key={unit.id} value={unit.id} className="px-2">
             <AccordionTrigger>
               <div className="flex flex-col gap-1 text-left">
                 <span className="text-xs font-semibold uppercase tracking-wide text-rose-600">
@@ -129,58 +188,87 @@ export function StudentCurriculumView({ classId }: StudentCurriculumViewProps) {
               </div>
             </AccordionTrigger>
             <AccordionContent className="px-1 pb-4">
-              {unit.lessons.length > 0 ? (
-                <ol className="space-y-3">
-                  {unit.lessons.map(lesson => (
-                    <li
-                      key={lesson.id}
-                      onClick={() => router.push(`/student/classes/${classId}/lessons/${lesson.slug}`)}
-                      className="rounded-lg border border-gray-100 bg-white p-4 shadow-sm transition hover:border-rose-200 hover:shadow-md cursor-pointer"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2">
-                            {lesson.completed ? (
-                              <CheckCircle2 className="h-5 w-5 text-green-600 flex-shrink-0" />
-                            ) : lesson.started ? (
-                              <Circle className="h-5 w-5 text-blue-600 flex-shrink-0" />
-                            ) : (
-                              <Circle className="h-5 w-5 text-gray-300 flex-shrink-0" />
-                            )}
-                            <div>
-                              <p className="text-xs font-semibold uppercase tracking-wide text-rose-500">
-                                Lesson {lesson.order}
-                              </p>
-                              <p className="text-base font-medium text-gray-900">{lesson.title}</p>
-                              {lesson.titleThai !== lesson.title && (
-                                <p className="text-sm text-gray-600">{lesson.titleThai}</p>
-                              )}
+                  {unit.lessons.length > 0 ? (
+                    <ol className="space-y-3">
+                      {unit.lessons.map(lesson => {
+                        const status = lesson.progress?.status ?? 'NOT_STARTED';
+                        const statusConfig = STATUS_CONFIG[status];
+                        const attemptsCount = lesson.progress?.attemptsCount ?? 0;
+                        const scorePercentage = lesson.progress?.mostRecentScorePercentage ?? null;
+                        const bestPercentage = lesson.progress?.bestScorePercentage ?? null;
+                        const hasScoreBadge = attemptsCount > 0 && typeof scorePercentage === 'number';
+
+                        const StatusIcon = statusConfig.icon;
+
+                        return (
+                          <li
+                            key={lesson.id}
+                            onClick={() => router.push(`/student/classes/${classId}/lessons/${lesson.slug}`)}
+                            className="cursor-pointer rounded-lg border border-gray-100 bg-white p-4 shadow-sm transition hover:border-rose-200 hover:shadow-md"
+                          >
+                            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                              <div className="flex flex-1 items-start gap-3">
+                                <StatusIcon className={`h-5 w-5 flex-shrink-0 ${statusConfig.iconClass}`} />
+                                <div>
+                                  <p className="text-xs font-semibold uppercase tracking-wide text-rose-500">
+                                    Lesson {lesson.order}
+                                  </p>
+                                  <p className="text-base font-medium text-gray-900">{lesson.title}</p>
+                                  {lesson.titleThai !== lesson.title && (
+                                    <p className="text-sm text-gray-600">{lesson.titleThai}</p>
+                                  )}
+                                </div>
+                              </div>
+                              <div className="flex items-center gap-3">
+                                <Badge variant="outline" className={statusConfig.badgeClass}>
+                                  {statusConfig.label}
+                                </Badge>
+                                {hasScoreBadge && (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span
+                                        className={`rounded-full border px-3 py-1 text-sm font-semibold ${getScoreBadgeClass(
+                                          scorePercentage!
+                                        )}`}
+                                      >
+                                        {Math.round(scorePercentage!)}%
+                                      </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="left" align="center">
+                                      <div className="space-y-1">
+                                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                          Attempt history
+                                        </p>
+                                        <div className="flex items-center justify-between gap-4 text-sm">
+                                          <span className="text-gray-500">Attempts</span>
+                                          <span className="font-semibold text-gray-900">{attemptsCount}</span>
+                                        </div>
+                                        <div className="flex items-center justify-between gap-4 text-sm">
+                                          <span className="text-gray-500">Most recent</span>
+                                          <span className="font-semibold text-gray-900">{formatPercentage(scorePercentage)}</span>
+                                        </div>
+                                        <div className="flex items-center justify-between gap-4 text-sm">
+                                          <span className="text-gray-500">Best</span>
+                                          <span className="font-semibold text-gray-900">{formatPercentage(bestPercentage)}</span>
+                                        </div>
+                                      </div>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
+                              </div>
                             </div>
-                          </div>
-                        </div>
-                        <div className="flex gap-2">
-                          {lesson.completed && (
-                            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                              Completed
-                            </Badge>
-                          )}
-                          {lesson.started && !lesson.completed && (
-                            <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
-                              In Progress
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                    </li>
-                  ))}
-                </ol>
-              ) : (
-                <p className="text-sm text-gray-500">No lessons added yet.</p>
-              )}
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  ) : (
+                    <p className="text-sm text-gray-500">No lessons added yet.</p>
+                  )}
             </AccordionContent>
           </AccordionItem>
-        ))}
-      </Accordion>
+          ))}
+        </Accordion>
+      </TooltipProvider>
     </div>
   );
 }

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+

--- a/docs/sprint/S3-Interactive-Learning.md
+++ b/docs/sprint/S3-Interactive-Learning.md
@@ -496,6 +496,9 @@ The system SHALL include reading comprehension questions that reference lesson t
 - E2E test: Full flow from lesson view → quiz → results → curriculum with updated badge
 
 **Labels**: type:feature,area:frontend,area:backend,priority:P1
+**Status**: In Progress
+**Started**: 2025-10-25
+**Branch**: feat/95-lesson-progress-tracking
 **Affected Specs**: docs/specs/progress-tracking/spec.md
 **Change Type**: ADDED
 **Agent Assignment**: dev (Full-stack Developer)


### PR DESCRIPTION
## Summary

Implements comprehensive lesson progress tracking for students, enabling them to monitor their learning journey through visual progress indicators, score badges, and detailed attempt history across the curriculum and lesson views.

## Changes

**New API Endpoint:**
- ✅ `GET /api/students/{studentId}/lessons/{lessonId}/progress`
  - Returns: completion status, attempt count, scores (recent/best), timestamps
  - Authorization: Students access own progress, teachers access class students' progress
  - Auth: 401 if unauthenticated, 403 if unauthorized, 404 if not found

**Enhanced API Endpoint:**
- ✅ `GET /api/classes/{classId}/curriculum` now includes progress data
  - Embedded progress object for each lesson with status, scores, attempts
  - Single query optimization using Map-based lookups

**Components:**

1. **StudentCurriculumView** (Enhanced):
   - Progress badges showing completion status (gray/yellow/green)
   - Score badges with color coding (blue ≥90%, green ≥80%, yellow ≥60%, red <60%)
   - Interactive tooltips displaying:
     - Total attempts
     - Most recent score
     - Best score
   - Radix UI Tooltip component with 200ms delay

2. **LessonViewer** (Enhanced):
   - Progress summary card at bottom of lesson content
   - Displays completion status and score badges
   - Dynamic CTAs:
     - "Start Quiz" when no attempts exist
     - "Retake Quiz" when attempts exist
   - Real-time progress refresh after quiz completion

3. **QuizPlayer** (Enhanced):
   - Triggers `onQuizCompleted` callback after submission
   - Enables parent components to refresh progress data

4. **Tooltip Component** (New):
   - Added shadcn/ui Tooltip primitive from Radix UI
   - Accessible, keyboard-navigable tooltip system
   - Used for progress badge hover interactions

**Database Logic:**

- ✅ Quiz submission now tracks `totalTimeSpentSeconds`
  - Calculates time from all question responses in attempt
  - Cumulative across all attempts
- ✅ Completion status set to `COMPLETED` on any quiz submission
  - Matches spec requirement: "any score counts as completed"
- ✅ Tracks both `bestScore` and `mostRecentScore` separately
- ✅ Updates `lastAttemptAt` and `completedAt` timestamps

**Testing:**

- ✅ Integration tests updated for curriculum API progress fields
- ✅ Build successful (`npm run build` passes)
- ✅ Linter passing (`npm run lint` - 0 errors, 43 pre-existing warnings)
- ✅ Manual testing verified with real database

## Acceptance Criteria

From issue #95:

- [x] Lesson cards in curriculum view display completion status (not started / started / completed)
- [x] Completed lessons show score badge with color coding (≥90% blue, ≥80% green, <80% yellow, <60% red)
- [x] Badge displays most recent score percentage
- [x] Hover tooltip shows: attempt count, most recent score, best score
- [x] "Start Quiz" button appears at end of lesson content when no attempts exist
- [x] "Retake Quiz" button appears when at least one attempt exists
- [x] Clicking quiz button navigates to quiz interface
- [x] After quiz submission, student returns to lesson view with updated score badge
- [x] API endpoint `GET /api/students/{studentId}/lessons/{lessonId}/progress` returns completion data
- [x] Completion status updated automatically after quiz submission (any score = completed)

## API Contract

### GET /api/students/{studentId}/lessons/{lessonId}/progress

**Request:**
```
GET /api/students/me/lessons/g3-introduction-to-science/progress
Authorization: Bearer <session-token>
```

**Response (200 OK):**
```json
{
  "status": "COMPLETED",
  "attemptsCount": 2,
  "mostRecentScore": 8.5,
  "mostRecentScorePercentage": 85,
  "bestScore": 9.0,
  "bestScorePercentage": 90,
  "lastAttemptAt": "2025-10-25T10:30:00.000Z",
  "completedAt": "2025-10-25T09:15:00.000Z"
}
```

**Error Responses:**
- `401 Unauthorized` - Not authenticated
- `403 Forbidden` - Not authorized to view this student's progress
- `404 Not Found` - Lesson or student not found
- `500 Internal Server Error` - Unexpected error

### GET /api/classes/{classId}/curriculum (Enhanced)

**Response:** Now includes nested `progress` object in each lesson:
```json
{
  "class": { "id": "...", "name": "...", ... },
  "units": [
    {
      "id": "...",
      "title": "...",
      "lessons": [
        {
          "id": "...",
          "title": "...",
          "progress": {
            "status": "COMPLETED",
            "attemptsCount": 2,
            "mostRecentScorePercentage": 85,
            "bestScorePercentage": 90
          }
        }
      ]
    }
  ]
}
```

## Screenshots

_(Manual testing recommended for UI verification)_

**Key UI Elements:**
1. Curriculum view with progress badges (status + score)
2. Lesson detail page with progress summary card
3. Tooltip hover showing attempt history
4. "Start Quiz" vs "Retake Quiz" CTAs

## Test Plan

**Manual Test Scenarios:**

```bash
# Scenario 1: First-time lesson access
1. Sign in as student
2. Navigate to /student/classes/{classId}
3. Select lesson with no attempts
4. Verify lesson card shows "Not Started" gray badge
5. Open lesson detail page
6. Verify "Start Quiz" button appears
7. Click "Start Quiz" → Navigate to quiz

# Scenario 2: Complete quiz and verify updates
1. Complete quiz with 85% score
2. Submit quiz
3. Verify redirect back to lesson view
4. Verify progress card shows:
   - Status: "Completed" (green badge)
   - Score: 85% (green score badge)
   - Attempts: 1
4. Navigate back to curriculum
5. Verify lesson card shows:
   - Green "Completed" badge
   - Green "85%" score badge
6. Hover over score badge
7. Verify tooltip shows:
   - Attempts: 1
   - Recent: 85%
   - Best: 85%

# Scenario 3: Retake quiz
1. Return to lesson detail page
2. Verify "Retake Quiz" button appears (not "Start Quiz")
3. Click "Retake Quiz"
4. Complete with 90% score
5. Verify progress updates:
   - Recent: 90%
   - Best: 90%
   - Attempts: 2
6. Verify score badge changes to blue (≥90%)

# Scenario 4: Low score handling
1. Complete quiz with 55% score
2. Verify:
   - Status still "Completed" (any score counts)
   - Score badge is red (<60%)
   - Tooltip shows accurate data

# Scenario 5: Teacher view
1. Sign in as teacher
2. Use progress API for student in class: GET /api/students/{studentId}/lessons/{lessonId}/progress
3. Verify teacher can access student progress
4. Try accessing student NOT in class → 403

# Scenario 6: Authorization
1. Sign out
2. Try accessing progress API → 401
3. Sign in as student
4. Try accessing another student's progress → 403
```

**Integration Tests:**
- ✅ Curriculum API tests updated (lines 353-361 in `route.integration.test.ts`)
- ⚠️ **TODO:** Add integration tests for new progress endpoint (see follow-up section)

**Build & Lint:**
- ✅ `npm run build` - Successful (30.3s compile time)
- ✅ `npm run lint` - 0 errors, 43 warnings (all pre-existing)

## Known Limitations & Future Enhancements

### Current Limitations:

1. **No Thai translations for lesson titles**
   - Schema doesn't support `titleThai` field yet
   - Currently displays English title for both fields
   - TODO: Add Thai translations when schema supports it

2. **Slug field uses lesson ID**
   - Schema doesn't have `slug` field yet
   - TODO: Use proper slug field when added

3. **Missing integration tests for progress endpoint**
   - New `/api/students/[studentId]/lessons/[lessonId]/progress` endpoint needs tests
   - See "Follow-up Work" section below

### Code Review Notes:

From comprehensive code review by code-reviewer agent:

**Strengths:**
- ✅ Strong TypeScript typing throughout
- ✅ Comprehensive error handling with appropriate HTTP status codes
- ✅ Multi-layered authorization (authentication → authorization → data access)
- ✅ Database efficiency (Map-based O(1) lookups, single queries)
- ✅ Proper React hooks usage (`useCallback`, `useMemo` with correct dependencies)
- ✅ Accessibility: semantic HTML, ARIA support via Radix UI
- ✅ Color + text labels on badges (not color alone)

**Addressed Issues:**
- ✅ Fixed syntax error (extra closing brace in curriculum route)
- ✅ Implemented `totalTimeSpentSeconds` tracking (was missing)
- ✅ Proper time calculation from question responses

**Suggestions for Follow-up (Optional):**
- 💡 Extract shared types to `lib/types/lesson-progress.ts` (reduce duplication)
- 💡 Extract score badge utilities to `lib/utils/score-badge.ts` (DRY)
- 💡 Consider extracting `LessonProgressCard` component (reduce component complexity)
- 💡 Optimize authorization query in progress route (potential N+1)

## Follow-up Work

**Required for Production:**
- [ ] Add integration tests for `GET /api/students/[studentId]/lessons/[lessonId]/progress`
  - Test scenarios: auth, self-access, teacher-access, unauthorized, not found
  - File: `app/api/students/[studentId]/lessons/[lessonId]/progress/route.integration.test.ts`

**Nice to Have:**
- [ ] Add E2E test for complete flow: lesson → quiz → updated progress
- [ ] Extract shared types to `lib/types/lesson-progress.ts`
- [ ] Add input validation for `studentId` and `lessonId` parameters (UUID format)

## Database Verification

```sql
-- Verify LessonCompletion records include time tracking
SELECT 
  id, 
  studentId, 
  lessonId, 
  status, 
  attemptsCount,
  totalTimeSpentSeconds,
  mostRecentScorePercentage,
  bestScorePercentage
FROM "LessonCompletion"
WHERE status = 'COMPLETED'
LIMIT 5;
```

## Related Issues

- Closes #95 - Story: Lesson Progress Tracking
- Part of Sprint 3: Interactive Learning milestone

## Dependencies

- Next.js 16.0.0
- Radix UI (@radix-ui/react-tooltip)
- Prisma ORM
- shadcn/ui components

## Breaking Changes

None - All changes are additive.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>