### PR TITLE
feat: Design Lesson Content JSON Schema

### DIFF
--- a/lib/schemas/__tests__/lesson-content.schema.test.ts
+++ b/lib/schemas/__tests__/lesson-content.schema.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+import {
+  TextBlockSchema,
+  VocabularyBlockSchema,
+  ImageBlockSchema,
+  ReadingPassageBlockSchema,
+  ProcedureBlockSchema,
+  MaterialsBlockSchema,
+  ContentBlockSchema,
+  LessonContentSchema,
+  validateLessonContent,
+  isValidLessonContent,
+  type LessonContent,
+  type ContentBlock,
+} from '../lesson-content.schema';
+
+describe('Lesson Content Schema', () => {
+  describe('TextBlockSchema', () => {
+    it('should parse valid text block correctly', () => {
+      const input = {
+        type: 'text',
+        content: 'Welcome to today\'s lesson on photosynthesis.',
+      };
+
+      const result = TextBlockSchema.parse(input);
+
+      expect(result.type).toBe('text');
+      expect(result.content).toBe('Welcome to today\'s lesson on photosynthesis.');
+      expect(result.contentThai).toBeUndefined();
+    });
+
+    it('should parse text block with Thai translation', () => {
+      const input = {
+        type: 'text',
+        content: 'Welcome to today\'s lesson.',
+        contentThai: 'ยินดีต้อนรับสู่บทเรียนวันนี้',
+      };
+
+      const result = TextBlockSchema.parse(input);
+
+      expect(result.content).toBe('Welcome to today\'s lesson.');
+      expect(result.contentThai).toBe('ยินดีต้อนรับสู่บทเรียนวันนี้');
+    });
+
+    it('should reject text block with empty content', () => {
+      const input = {
+        type: 'text',
+        content: '',
+      };
+
+      expect(() => TextBlockSchema.parse(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('VocabularyBlockSchema', () => {
+    it('should parse valid vocabulary block with multiple terms', () => {
+      const input = {
+        type: 'vocabulary',
+        terms: [
+          {
+            term: 'Photosynthesis',
+            thai: 'การสังเคราะห์ด้วยแสง',
+            definition: 'The process by which plants convert sunlight into energy',
+          },
+          {
+            term: 'Chlorophyll',
+            thai: 'คลอโรฟิลล์',
+            definition: 'The green pigment in plants',
+            audioUrl: 'https://example.com/audio/chlorophyll.mp3',
+          },
+        ],
+      };
+
+      const result = VocabularyBlockSchema.parse(input);
+
+      expect(result.type).toBe('vocabulary');
+      expect(result.terms).toHaveLength(2);
+      expect(result.terms[0].term).toBe('Photosynthesis');
+      expect(result.terms[0].audioUrl).toBeUndefined();
+      expect(result.terms[1].audioUrl).toBe('https://example.com/audio/chlorophyll.mp3');
+    });
+
+    it('should reject vocabulary block with empty terms array', () => {
+      const input = {
+        type: 'vocabulary',
+        terms: [],
+      };
+
+      expect(() => VocabularyBlockSchema.parse(input)).toThrow(ZodError);
+    });
+
+    it('should reject term with invalid audioUrl', () => {
+      const input = {
+        type: 'vocabulary',
+        terms: [
+          {
+            term: 'Test',
+            thai: 'ทดสอบ',
+            definition: 'A test term',
+            audioUrl: 'not-a-valid-url',
+          },
+        ],
+      };
+
+      expect(() => VocabularyBlockSchema.parse(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('ImageBlockSchema', () => {
+    it('should parse valid image block with optional fields', () => {
+      const input = {
+        type: 'image',
+        src: '/images/plant-diagram.png',
+        alt: 'Diagram showing the parts of a plant involved in photosynthesis',
+        caption: 'Parts of a plant',
+        captionThai: 'ส่วนต่างๆ ของพืช',
+        aspectRatio: 1.5,
+        attribution: 'Science Textbook, 2024',
+      };
+
+      const result = ImageBlockSchema.parse(input);
+
+      expect(result.type).toBe('image');
+      expect(result.src).toBe('/images/plant-diagram.png');
+      expect(result.alt).toBe('Diagram showing the parts of a plant involved in photosynthesis');
+      expect(result.caption).toBe('Parts of a plant');
+      expect(result.captionThai).toBe('ส่วนต่างๆ ของพืช');
+      expect(result.aspectRatio).toBe(1.5);
+      expect(result.attribution).toBe('Science Textbook, 2024');
+    });
+
+    it('should parse image block without optional fields', () => {
+      const input = {
+        type: 'image',
+        src: '/images/diagram.png',
+        alt: 'A detailed diagram showing plant anatomy',
+      };
+
+      const result = ImageBlockSchema.parse(input);
+
+      expect(result.caption).toBeUndefined();
+      expect(result.aspectRatio).toBeUndefined();
+    });
+
+    it('should reject image with alt text shorter than 10 characters', () => {
+      const input = {
+        type: 'image',
+        src: '/images/diagram.png',
+        alt: 'Plant',
+      };
+
+      expect(() => ImageBlockSchema.parse(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('ReadingPassageBlockSchema', () => {
+    it('should parse valid reading passage with word count', () => {
+      const input = {
+        type: 'reading_passage',
+        title: 'How Plants Make Food',
+        titleThai: 'พืชสร้างอาหารอย่างไร',
+        content: 'Plants are amazing organisms that can make their own food through photosynthesis.',
+        contentThai: 'พืชเป็นสิ่งมีชีวิตที่น่าทึ่งที่สามารถสร้างอาหารเองได้ผ่านการสังเคราะห์ด้วยแสง',
+        wordCount: 150,
+      };
+
+      const result = ReadingPassageBlockSchema.parse(input);
+
+      expect(result.type).toBe('reading_passage');
+      expect(result.title).toBe('How Plants Make Food');
+      expect(result.wordCount).toBe(150);
+    });
+
+    it('should reject reading passage with negative word count', () => {
+      const input = {
+        type: 'reading_passage',
+        title: 'Test',
+        content: 'Content here',
+        wordCount: -5,
+      };
+
+      expect(() => ReadingPassageBlockSchema.parse(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('ProcedureBlockSchema', () => {
+    it('should parse valid procedure with nested sub-steps', () => {
+      const input = {
+        type: 'procedure',
+        steps: [
+          {
+            stepNumber: 1,
+            instruction: 'Place one plant in sunlight',
+            instructionThai: 'วางต้นไม้หนึ่งต้นไว้ในที่มีแสงแดด',
+            subSteps: ['Choose a sunny windowsill', 'Ensure the plant is stable'],
+          },
+          {
+            stepNumber: 2,
+            instruction: 'Place the other plant in a dark closet',
+          },
+        ],
+      };
+
+      const result = ProcedureBlockSchema.parse(input);
+
+      expect(result.type).toBe('procedure');
+      expect(result.steps).toHaveLength(2);
+      expect(result.steps[0].stepNumber).toBe(1);
+      expect(result.steps[0].subSteps).toEqual(['Choose a sunny windowsill', 'Ensure the plant is stable']);
+      expect(result.steps[1].subSteps).toBeUndefined();
+    });
+
+    it('should reject procedure with non-positive step number', () => {
+      const input = {
+        type: 'procedure',
+        steps: [
+          {
+            stepNumber: 0,
+            instruction: 'Invalid step',
+          },
+        ],
+      };
+
+      expect(() => ProcedureBlockSchema.parse(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('MaterialsBlockSchema', () => {
+    it('should parse valid materials block', () => {
+      const input = {
+        type: 'materials',
+        items: [
+          { quantity: '2', item: 'Small plants', itemThai: 'ต้นไม้ขนาดเล็ก' },
+          { item: 'Water' },
+        ],
+      };
+
+      const result = MaterialsBlockSchema.parse(input);
+
+      expect(result.type).toBe('materials');
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].quantity).toBe('2');
+      expect(result.items[0].itemThai).toBe('ต้นไม้ขนาดเล็ก');
+      expect(result.items[1].quantity).toBeUndefined();
+    });
+  });
+
+  describe('ContentBlockSchema (discriminated union)', () => {
+    it('should reject invalid block type', () => {
+      const input = {
+        type: 'unknown_type',
+        content: 'Some content',
+      };
+
+      expect(() => ContentBlockSchema.parse(input)).toThrow(ZodError);
+    });
+
+    it('should correctly parse different block types', () => {
+      const textBlock: ContentBlock = ContentBlockSchema.parse({
+        type: 'text',
+        content: 'Hello world',
+      });
+      expect(textBlock.type).toBe('text');
+
+      const vocabBlock: ContentBlock = ContentBlockSchema.parse({
+        type: 'vocabulary',
+        terms: [{ term: 'Test', thai: 'ทดสอบ', definition: 'A test' }],
+      });
+      expect(vocabBlock.type).toBe('vocabulary');
+    });
+  });
+
+  describe('LessonContentSchema', () => {
+    it('should parse full lesson content with mixed blocks and version field', () => {
+      const input = {
+        version: 1,
+        blocks: [
+          {
+            id: 'intro',
+            type: 'text',
+            content: 'Welcome to the lesson',
+          },
+          {
+            type: 'vocabulary',
+            terms: [
+              {
+                term: 'Photosynthesis',
+                thai: 'การสังเคราะห์ด้วยแสง',
+                definition: 'Plant food-making process',
+              },
+            ],
+          },
+          {
+            type: 'image',
+            src: '/images/plant.png',
+            alt: 'A beautiful green plant in a pot',
+          },
+          {
+            type: 'reading_passage',
+            title: 'About Plants',
+            content: 'Plants are organisms...',
+            wordCount: 50,
+          },
+          {
+            type: 'materials',
+            items: [{ item: 'Soil' }],
+          },
+          {
+            type: 'procedure',
+            steps: [{ stepNumber: 1, instruction: 'Plant the seed' }],
+          },
+        ],
+      };
+
+      const result = LessonContentSchema.parse(input);
+
+      expect(result.version).toBe(1);
+      expect(result.blocks).toHaveLength(6);
+      expect(result.blocks[0].type).toBe('text');
+      expect(result.blocks[1].type).toBe('vocabulary');
+      expect(result.blocks[2].type).toBe('image');
+      expect(result.blocks[3].type).toBe('reading_passage');
+      expect(result.blocks[4].type).toBe('materials');
+      expect(result.blocks[5].type).toBe('procedure');
+    });
+
+    it('should reject lesson content without version field', () => {
+      const input = {
+        blocks: [{ type: 'text', content: 'Hello' }],
+      };
+
+      expect(() => LessonContentSchema.parse(input)).toThrow(ZodError);
+    });
+
+    it('should reject lesson content with wrong version', () => {
+      const input = {
+        version: 2,
+        blocks: [{ type: 'text', content: 'Hello' }],
+      };
+
+      expect(() => LessonContentSchema.parse(input)).toThrow(ZodError);
+    });
+
+    it('should strip unknown fields for forward compatibility', () => {
+      const input = {
+        version: 1,
+        blocks: [{ type: 'text', content: 'Hello' }],
+        futureField: 'should be stripped',
+        anotherUnknown: 123,
+      };
+
+      const result = LessonContentSchema.parse(input);
+
+      expect(result.version).toBe(1);
+      expect(result.blocks).toHaveLength(1);
+      expect((result as Record<string, unknown>).futureField).toBeUndefined();
+      expect((result as Record<string, unknown>).anotherUnknown).toBeUndefined();
+    });
+
+    it('should preserve block id field when provided', () => {
+      const input = {
+        version: 1,
+        blocks: [
+          {
+            id: 'my-custom-id',
+            type: 'text',
+            content: 'Hello world',
+          },
+          {
+            type: 'vocabulary',
+            terms: [{ term: 'Test', thai: 'ทดสอบ', definition: 'A test' }],
+          },
+        ],
+      };
+
+      const result = LessonContentSchema.parse(input);
+
+      expect(result.blocks[0].id).toBe('my-custom-id');
+      expect(result.blocks[1].id).toBeUndefined();
+    });
+  });
+
+  describe('validateLessonContent', () => {
+    it('should return validated content for valid data', () => {
+      const input = {
+        version: 1,
+        blocks: [{ type: 'text', content: 'Valid content' }],
+      };
+
+      const result = validateLessonContent(input);
+
+      expect(result.version).toBe(1);
+      expect(result.blocks[0].type).toBe('text');
+    });
+
+    it('should throw ZodError on invalid data', () => {
+      const input = {
+        version: 1,
+        blocks: [{ type: 'invalid', content: 'Bad block' }],
+      };
+
+      expect(() => validateLessonContent(input)).toThrow(ZodError);
+    });
+
+    it('should throw ZodError with missing required fields', () => {
+      const input = {
+        version: 1,
+        blocks: [{ type: 'text' }], // missing 'content'
+      };
+
+      expect(() => validateLessonContent(input)).toThrow(ZodError);
+    });
+  });
+
+  describe('isValidLessonContent', () => {
+    it('should return true for valid data', () => {
+      const input = {
+        version: 1,
+        blocks: [{ type: 'text', content: 'Valid content' }],
+      };
+
+      expect(isValidLessonContent(input)).toBe(true);
+    });
+
+    it('should return false for invalid data', () => {
+      const invalidInputs = [
+        { version: 1, blocks: [{ type: 'invalid' }] },
+        { blocks: [{ type: 'text', content: 'Missing version' }] },
+        { version: 2, blocks: [] },
+        null,
+        undefined,
+        'not an object',
+        { version: 1 }, // missing blocks
+      ];
+
+      for (const input of invalidInputs) {
+        expect(isValidLessonContent(input)).toBe(false);
+      }
+    });
+
+    it('should serve as type guard', () => {
+      const unknownData: unknown = {
+        version: 1,
+        blocks: [{ type: 'text', content: 'Hello' }],
+      };
+
+      if (isValidLessonContent(unknownData)) {
+        // TypeScript should know this is LessonContent
+        const content: LessonContent = unknownData;
+        expect(content.version).toBe(1);
+      }
+    });
+  });
+});

--- a/lib/schemas/lesson-content.schema.ts
+++ b/lib/schemas/lesson-content.schema.ts
@@ -1,0 +1,272 @@
+/**
+ * Lesson Content JSON Schema
+ *
+ * Defines Zod schemas and TypeScript types for structured lesson content blocks.
+ * These schemas enable the frontend to render rich, interactive lesson experiences
+ * with vocabulary flashcards, reading passages, procedures, materials lists, and media.
+ *
+ * @example JSON structure:
+ * ```json
+ * {
+ *   "version": 1,
+ *   "blocks": [
+ *     {
+ *       "id": "intro-text",
+ *       "type": "text",
+ *       "content": "Welcome to today's lesson on photosynthesis.",
+ *       "contentThai": "ยินดีต้อนรับสู่บทเรียนวันนี้เกี่ยวกับการสังเคราะห์ด้วยแสง"
+ *     },
+ *     {
+ *       "type": "vocabulary",
+ *       "terms": [
+ *         {
+ *           "term": "Photosynthesis",
+ *           "thai": "การสังเคราะห์ด้วยแสง",
+ *           "definition": "The process by which plants convert sunlight into energy",
+ *           "audioUrl": "/audio/photosynthesis.mp3"
+ *         }
+ *       ]
+ *     },
+ *     {
+ *       "type": "image",
+ *       "src": "/images/plant-diagram.png",
+ *       "alt": "Diagram showing the parts of a plant involved in photosynthesis",
+ *       "caption": "Parts of a plant",
+ *       "captionThai": "ส่วนต่างๆ ของพืช",
+ *       "aspectRatio": 1.5,
+ *       "attribution": "Science Textbook, 2024"
+ *     },
+ *     {
+ *       "type": "reading_passage",
+ *       "title": "How Plants Make Food",
+ *       "titleThai": "พืชสร้างอาหารอย่างไร",
+ *       "content": "Plants are amazing organisms that can make their own food...",
+ *       "contentThai": "พืชเป็นสิ่งมีชีวิตที่น่าทึ่งที่สามารถสร้างอาหารเองได้...",
+ *       "wordCount": 150
+ *     },
+ *     {
+ *       "type": "materials",
+ *       "items": [
+ *         { "quantity": "2", "item": "Small plants", "itemThai": "ต้นไม้ขนาดเล็ก" },
+ *         { "item": "Water" }
+ *       ]
+ *     },
+ *     {
+ *       "type": "procedure",
+ *       "steps": [
+ *         {
+ *           "stepNumber": 1,
+ *           "instruction": "Place one plant in sunlight",
+ *           "instructionThai": "วางต้นไม้หนึ่งต้นไว้ในที่มีแสงแดด",
+ *           "subSteps": ["Choose a sunny windowsill", "Ensure the plant is stable"]
+ *         },
+ *         {
+ *           "stepNumber": 2,
+ *           "instruction": "Place the other plant in a dark closet"
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * ```
+ */
+
+import { z, ZodError } from 'zod';
+
+// =============================================================================
+// Sub-schemas for complex nested structures
+// =============================================================================
+
+/**
+ * Schema for a vocabulary term with optional Thai translation and audio
+ */
+export const VocabularyTermSchema = z.object({
+  term: z.string().min(1, 'Term is required'),
+  thai: z.string().min(1, 'Thai translation is required'),
+  definition: z.string().min(1, 'Definition is required'),
+  audioUrl: z.string().url().optional(),
+});
+
+/**
+ * Schema for a material item in a materials list
+ */
+export const MaterialItemSchema = z.object({
+  quantity: z.string().optional(),
+  item: z.string().min(1, 'Item name is required'),
+  itemThai: z.string().optional(),
+});
+
+/**
+ * Schema for a procedure step with optional sub-steps
+ */
+export const ProcedureStepSchema = z.object({
+  stepNumber: z.number().int().positive('Step number must be positive'),
+  instruction: z.string().min(1, 'Instruction is required'),
+  instructionThai: z.string().optional(),
+  subSteps: z.array(z.string()).optional(),
+});
+
+// =============================================================================
+// Content Block Schemas
+// =============================================================================
+
+/**
+ * Text block for general content
+ */
+export const TextBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('text'),
+  content: z.string().min(1, 'Content is required'),
+  contentThai: z.string().optional(),
+});
+
+/**
+ * Vocabulary block containing a list of terms
+ */
+export const VocabularyBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('vocabulary'),
+  terms: z.array(VocabularyTermSchema).min(1, 'At least one term is required'),
+});
+
+/**
+ * Image block with accessibility requirements
+ */
+export const ImageBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('image'),
+  src: z.string().min(1, 'Image source is required'),
+  alt: z.string().min(10, 'Alt text must be at least 10 characters for accessibility'),
+  caption: z.string().optional(),
+  captionThai: z.string().optional(),
+  aspectRatio: z.number().positive().optional(),
+  attribution: z.string().optional(),
+});
+
+/**
+ * Reading passage block for longer text content
+ */
+export const ReadingPassageBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('reading_passage'),
+  title: z.string().min(1, 'Title is required'),
+  titleThai: z.string().optional(),
+  content: z.string().min(1, 'Content is required'),
+  contentThai: z.string().optional(),
+  wordCount: z.number().int().nonnegative('Word count must be non-negative'),
+});
+
+/**
+ * Procedure block for step-by-step instructions
+ */
+export const ProcedureBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('procedure'),
+  steps: z.array(ProcedureStepSchema).min(1, 'At least one step is required'),
+});
+
+/**
+ * Materials block for listing required items
+ */
+export const MaterialsBlockSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('materials'),
+  items: z.array(MaterialItemSchema).min(1, 'At least one item is required'),
+});
+
+// =============================================================================
+// Discriminated Union for All Content Blocks
+// =============================================================================
+
+/**
+ * Discriminated union of all content block types
+ * Uses the `type` field to discriminate between block schemas
+ */
+export const ContentBlockSchema = z.discriminatedUnion('type', [
+  TextBlockSchema,
+  VocabularyBlockSchema,
+  ImageBlockSchema,
+  ReadingPassageBlockSchema,
+  ProcedureBlockSchema,
+  MaterialsBlockSchema,
+]);
+
+// =============================================================================
+// Root Lesson Content Schema
+// =============================================================================
+
+/**
+ * Root schema for lesson content with version and blocks array
+ * Uses `.strip()` to remove unknown fields for forward compatibility
+ */
+export const LessonContentSchema = z.object({
+  version: z.literal(1),
+  blocks: z.array(ContentBlockSchema),
+}).strip();
+
+// =============================================================================
+// TypeScript Types (inferred from schemas)
+// =============================================================================
+
+export type VocabularyTerm = z.infer<typeof VocabularyTermSchema>;
+export type MaterialItem = z.infer<typeof MaterialItemSchema>;
+export type ProcedureStep = z.infer<typeof ProcedureStepSchema>;
+
+export type TextBlock = z.infer<typeof TextBlockSchema>;
+export type VocabularyBlock = z.infer<typeof VocabularyBlockSchema>;
+export type ImageBlock = z.infer<typeof ImageBlockSchema>;
+export type ReadingPassageBlock = z.infer<typeof ReadingPassageBlockSchema>;
+export type ProcedureBlock = z.infer<typeof ProcedureBlockSchema>;
+export type MaterialsBlock = z.infer<typeof MaterialsBlockSchema>;
+
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+export type LessonContent = z.infer<typeof LessonContentSchema>;
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Validate lesson content data against the schema
+ * Throws ZodError if validation fails
+ *
+ * @param data - Unknown data to validate
+ * @returns Validated and typed LessonContent
+ * @throws {ZodError} If validation fails
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const content = validateLessonContent(jsonData);
+ *   console.log(content.blocks.length);
+ * } catch (error) {
+ *   if (error instanceof ZodError) {
+ *     console.error('Validation errors:', error.issues);
+ *   }
+ * }
+ * ```
+ */
+export function validateLessonContent(data: unknown): LessonContent {
+  return LessonContentSchema.parse(data);
+}
+
+/**
+ * Check if data is valid lesson content without throwing
+ *
+ * @param data - Unknown data to validate
+ * @returns true if valid, false otherwise
+ *
+ * @example
+ * ```ts
+ * if (isValidLessonContent(jsonData)) {
+ *   // Safe to use as LessonContent
+ *   renderLesson(jsonData as LessonContent);
+ * }
+ * ```
+ */
+export function isValidLessonContent(data: unknown): data is LessonContent {
+  return LessonContentSchema.safeParse(data).success;
+}
+
+// Re-export ZodError for consumers to catch validation errors
+export { ZodError };


### PR DESCRIPTION
## Summary

- Define comprehensive Zod schemas and TypeScript interfaces for structured lesson content
- Add 6 block types: text, vocabulary, image, reading_passage, procedure, materials
- Implement discriminated union for type-safe block handling
- Add utility functions for validation: `validateLessonContent()` and `isValidLessonContent()`
- Include extensive JSDoc with example JSON structure

## Block Types

| Block Type | Description | Key Fields |
|------------|-------------|------------|
| `text` | General content | content, contentThai |
| `vocabulary` | Term flashcards | terms[] with term, thai, definition, audioUrl |
| `image` | Media with accessibility | src, alt (min 10 chars), caption, aspectRatio |
| `reading_passage` | Long-form text | title, content, wordCount |
| `procedure` | Step-by-step instructions | steps[] with subSteps support |
| `materials` | Required items list | items[] with quantity, item |

## Design Decisions

1. **Version field**: Schema includes `version: 1` for future migrations
2. **Forward compatibility**: Unknown fields stripped (not rejected) for extensibility
3. **Accessibility**: Image alt text requires minimum 10 characters
4. **Thai translation**: Optional Thai fields throughout for bilingual support
5. **Alignment**: Interfaces align with existing `lib/content-parsers.ts` types

## Test Plan

- [x] Valid text block parses correctly
- [x] Valid vocabulary block with multiple terms (including optional audioUrl)
- [x] Valid image block with optional caption and aspectRatio
- [x] Valid reading passage with word count
- [x] Valid procedure with nested sub-steps
- [x] Full lesson content with mixed blocks and version field
- [x] Invalid block type rejected
- [x] Missing required field rejected
- [x] validateLessonContent throws on invalid data
- [x] isValidLessonContent returns boolean
- [x] Unknown fields are stripped for forward compatibility
- [x] Block id field preserved when provided

**Test Results**: 27 tests passed

```
 ✓ lib/schemas/__tests__/lesson-content.schema.test.ts (27 tests) 93ms
 Test Files  1 passed (1)
 Tests       27 passed (27)
```

## Files Changed

- `lib/schemas/lesson-content.schema.ts` (new) - Schema definitions and utilities
- `lib/schemas/__tests__/lesson-content.schema.test.ts` (new) - Test suite

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)